### PR TITLE
fix: Make navbar fixed for consistent sticky behavior and glassy effect

### DIFF
--- a/about.css
+++ b/about.css
@@ -18,6 +18,7 @@ background-position: center;
 background-size: cover;
 position: relative;
 padding: 20px 0;
+margin-top: 40px;
 }
 
 nav {
@@ -27,7 +28,18 @@ nav {
     justify-content: space-between;
     align-items: center;
     padding: 0 5%;
-
+    padding: 0.75rem 5%;
+    margin-right: 6px;
+    background: rgba(163, 163, 163, 0.16);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+    position: fixed;
+    top: 0;
+    height: 6%;
+    width: 100%;
+    z-index: 999;
 }
 
 .text-box1 {

--- a/issue.css
+++ b/issue.css
@@ -13,6 +13,7 @@
         background-position: center;
         background-size: cover;
         position: relative;
+        padding-top: 20px;
     }
 
     nav {
@@ -21,7 +22,18 @@
         margin-right: 6px;
         justify-content: space-between;
         align-items: center;
-    
+        padding: 0.75rem 5%;
+        margin-right: 6px;
+        background: rgba(163, 163, 163, 0.16);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+        border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+        position: fixed;
+        top: 0;
+        height: 3%;
+        width: 90%;
+        z-index: 999
     }
 
     .header1 {

--- a/masthead.css
+++ b/masthead.css
@@ -24,6 +24,18 @@ nav {
   margin-right: 6px;
   justify-content: space-between;
   align-items: center;
+  padding: 0.75rem 5%;
+  margin-right: 6px;
+  background: rgba(177, 177, 177, 0.144);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+  position: fixed;
+  top: 0;
+  height: 6%;
+  width: 100%;
+  z-index: 999; 
 }
 
 .header1 {

--- a/style.css
+++ b/style.css
@@ -21,12 +21,20 @@ body{
 
 nav {
     display: flex;
-    /* margin-top: 6px; */
-    margin-right: 6px;
     justify-content: space-between;
     align-items: center;
-    padding: 0 5%;
-
+    padding: 0.75rem 5%;
+    margin-right: 6px;
+    background: rgba(45, 44, 44, 0.261);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+    position: fixed;
+    top: 0;
+    height: 5%;
+    width: 100%;
+    z-index: 999;
 }
 
 

--- a/submission.css
+++ b/submission.css
@@ -13,6 +13,7 @@ body {
   background-position: center;
   background-size: cover;
   position: relative;
+  padding-top: 6rem;
 }
 
 nav {
@@ -22,6 +23,18 @@ nav {
   justify-content: space-between;
   align-items: center;
   z-index: 1000;
+  padding: 0.75rem 5%;
+  margin-right: 6px;
+  background: rgba(163, 163, 163, 0.16);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+  position: fixed;
+  top: 0;
+  height: 3%;
+  width: 90%;
+  z-index: 999
 
 }
 


### PR DESCRIPTION
### 📌 Issue Reference
Closes #9 

### 🎯 Summary
This PR updates the navbar styling:
- Changes `position: sticky` → `position: fixed`
- Adds glassmorphic design using `backdrop-filter`, semi-transparent background, and shadow
- Ensures better compatibility and visibility across devices and scroll behaviors

---

### 🛠️ Implementation Details
- `position: fixed` used to ensure top placement even when `sticky` fails (due to ancestor scroll container or layout flow).
- Added:
  ```css
  background: rgba(255, 255, 255, 0.1);
  backdrop-filter: blur(10px);
  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
  top: 0;
  z-index: 1000;

---

### screenshots 📸

- before 
<img width="3024" height="1711" alt="image" src="https://github.com/user-attachments/assets/9d353cc0-6eee-4452-a690-83070bed00f0" />


- after 
<img width="3024" height="1742" alt="image" src="https://github.com/user-attachments/assets/183532fa-48fa-45d5-bed8-9ecd4b87865f" />

--

- before 
<img width="3024" height="1715" alt="image" src="https://github.com/user-attachments/assets/98af268b-7448-451a-82cc-8d20e002cfa4" />


- after 
<img width="3024" height="1741" alt="image" src="https://github.com/user-attachments/assets/89269b1c-4f15-4f54-a982-754a7839ee86" />

---

- before 
<img width="3024" height="1722" alt="image" src="https://github.com/user-attachments/assets/06e4d78c-35cd-48a8-85ac-3ca3f8c73699" />



- after 
<img width="3024" height="1729" alt="image" src="https://github.com/user-attachments/assets/def43da3-f2ae-40f7-b4bc-1b139b415c44" />

---

- before 
<img width="3024" height="1743" alt="image" src="https://github.com/user-attachments/assets/087abe60-89dc-4c5e-be77-9b144841ddda" />


- after 
<img width="3024" height="1748" alt="image" src="https://github.com/user-attachments/assets/d8527504-36dc-4c08-8b23-e1d72089f4e3" />

---
- before
<img width="3024" height="1719" alt="image" src="https://github.com/user-attachments/assets/e0fb40a7-916d-4905-991d-e66cd5280f56" />


- after
<img width="3024" height="1759" alt="image" src="https://github.com/user-attachments/assets/b98978aa-1039-413b-9b65-cd1fcb6d05aa" />

---
