### PR TITLE
Improve header styling and add border between sections in issue

### DIFF
--- a/issue.css
+++ b/issue.css
@@ -37,9 +37,9 @@
     }
 
     .header1 {
-    min-height: 26vh;
+    min-height:34vh;  
     width: 100%;
-    background-color: #fdf0d5;
+    background-color:#780000 ;
     background-position: center;
     background-size: cover;
     position: relative;
@@ -47,7 +47,7 @@
     
     
     .text-box1 {
-    color: #780000;
+    color: #fdf0d5;
     font-family:"Crimson Text", serif;
     width: 90%;
     position: absolute;
@@ -55,14 +55,20 @@
     left: 50%;
     transform: translate(-50%, -50%);
     text-align: center;
+
+    border-bottom: 5px solid #060000;
+    padding-bottom: 20px;
+    margin-bottom: 40px;
+    width:100%
     }
     
     .text-box1 h1 {
-        margin-top: 15px;
+        margin-top: 45px;
         font-weight: 700;
         font-style: italic;
         font-size: 62px;
         }
+
         .text-box1 p {
         margin: 10px 0 40px;
         font-size: 20px   
@@ -188,6 +194,15 @@ nav .fa {
         margin-top: 0;
         text-align: center;
         padding-top: 50px;
+
+
+
+        /*changed*/
+   border-bottom: 4px solid #060000;
+    padding-bottom: 100px;
+   
+    
+
         }
 
 .issuecover{


### PR DESCRIPTION
Edited .header1 background color, .text-box1 color and added border.
Changed margin-top of ,text-box1 h1.
Added border in .issues.
<img width="1882" height="360" alt="Screenshot 2025-07-23 005048" src="https://github.com/user-attachments/assets/cea73b54-6203-466f-9158-dcabf93a290d" />
<img width="957" height="523" alt="Screenshot 2025-07-23 005055" src="https://github.com/user-attachments/assets/de93f451-bc52-47b2-8e74-3fca7716e172" />
