### PR TITLE
fixed card text on about page pushed outside the card on mobile devices. 

### DIFF
--- a/about.css
+++ b/about.css
@@ -215,9 +215,6 @@ font-family: 'Times New Roman', Times, serif;
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
 }
-.landmarkInfo{
-    height: 35%;
-}
 .landmarks {
     background-color: #fdf0d5;
     padding: 50px 20px;


### PR DESCRIPTION
<img width="489" height="539" alt="image" src="https://github.com/user-attachments/assets/3e4a28a8-47a8-4007-9f34-838ae08b4aa8" />

fixed issue : The text on the cards were pushed outside the cards on some mobile devices.