### PR TITLE
Add: Change the text alignment vertically in about page

### DIFF
--- a/about.css
+++ b/about.css
@@ -250,7 +250,7 @@ font-family: 'Times New Roman', Times, serif;
 .landmarks h2 {
     font-size: 20px;
     color: #fdf0d5;
-    margin-bottom: 5px;
+    margin-bottom: 30px;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 


### PR DESCRIPTION
Related issue : #85

What I did : Adjusted the vertical alignment of text in the red section of the cards on the about page.
Why : The current text placement was too close to the "Know More" button, making the layout feel crowded. This change improves the visual spacing and UX.

Before : 
<img width="1350" height="579" alt="image" src="https://github.com/user-attachments/assets/424f32a5-7366-4651-8a3c-5771cbcb4d5f" />

After : 
<img width="1386" height="529" alt="image" src="https://github.com/user-attachments/assets/92b31eb2-463a-44f6-981d-2b7fe409dbcd" />

