### PR TITLE
Fix: Improve mobile responsiveness of team cards on masthead page

### DIFF
--- a/masthead.css
+++ b/masthead.css
@@ -220,11 +220,19 @@ nav .fa {
 
     .team-grid {
         grid-template-columns: 1fr;
+        padding: 0;
+        width: auto;
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 500px;
     }
-
-
-
-
+    .team-card {
+        width: 100%;
+        margin: 0 auto 1.5rem auto;
+        box-sizing: border-box;
+        padding: 1.2rem;
+        border-radius: 15px;
+    }
 
 }
 
@@ -576,4 +584,25 @@ nav .fa {
 .icons a {
   color: #fdf0d5;
   font-size: 25px;
+}
+
+@media (max-width: 700px) {
+    .team-container {
+        align-items: center;
+    }
+    .team-grid {
+        grid-template-columns: 1fr;
+        padding: 0;
+        width: auto;
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 500px;
+    }
+    .team-card {
+        width: 100%;
+        margin: 0 auto 1.5rem auto;
+        box-sizing: border-box;
+        padding: 1.2rem;
+        border-radius: 15px;
+    }
 }


### PR DESCRIPTION
This PR fixes Issue #27 by improving the mobile responsiveness of the team profile cards on the masthead page.

Changes made:
- Updated the CSS for `.team-card` to align the profile cards properly on small screens.
- Adjusted flexbox properties to prevent overlapping and ensure vertical stacking.
- Verified mobile view using developer tools.

Tested on both desktop and mobile views.

Please review and let me know if any further changes are needed.
