### PR TITLE
Fix: Centered header text below navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,13 +30,13 @@ body{
 }
 
 .header {
-    min-height: 26vh;
+    min-height: 60vh;
     width: 100%;
     background-color: #780000;
     background-position: center;
     background-size: cover;
     position: relative;
-    padding: 20px 0;
+    padding-top: 80px;
 }
 
 nav {
@@ -59,17 +59,14 @@ nav {
 
 
 
-
-.text-box{
-    color: #fdf0d5;
-    font-family:"Crimson Text", serif;
-    width: 90%;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    text-align: center;
+.text-box {
+  color: #fdf0d5;
+  font-family: "Crimson Text", serif;
+  width: 90%;
+  text-align: center;
+  margin: 0 auto;
 }
+
 
 .text-box h1 {
     margin-top: 15px;


### PR DESCRIPTION
## Contributor Info
Pranathi Sai Kalavagunta, GSSoC 25 Contributor.
github : pranuuk

---

## Related Issue
Fixes: #94 

---

## Description
- Fixed the issue where "The Cawnpore" heading was overlapping with the navbar.
- Used flexbox to vertically center the text within the header section.
- Removed absolute positioning from the .text-box and increased header height for better layout.


---

## Screenshots / Video (Before & After)
### Before:
<img width="1919" height="857" alt="Screenshot 2025-07-25 131520" src="https://github.com/user-attachments/assets/c3e6b7cc-2881-44c0-8c09-da40f1c152e3" />

### After:
<img width="1919" height="851" alt="image" src="https://github.com/user-attachments/assets/9ec33ff2-e4ff-4657-aa63-5bcffcc6fd58" />

---

## Checklist
- [✅ ] Mentioned the issue number in this PR.
- [ ✅] Created a separate branch (not `main`) before committing.
- [ ✅] Changes tested and verified.
- [ ✅] Attached necessary screenshots/videos for clarity.
- [ ✅] Code is clean, readable, and commented where necessary.
- [✅ ] No merge conflicts.
- [✅ ] Follows the design/style guide of the project.
- [✅ ] Added contributor name above.
- [ ✅] Confirmed that the feature fits well with the latest updated version of the website.


