### PR TITLE
fix: prevent navigation links from opening in new tabs

### DIFF
--- a/about.html
+++ b/about.html
@@ -23,11 +23,11 @@
             <i class="fa fa-times" onclick="hideMenu()"></i>
             <ul>
 
-                <li><a href="index.html" target="_blank">HOME</a></li>
-                <li><a href="about.html" target="_blank">ABOUT</a></li>
-                <li><a href="submission.html" target="_blank">SUBMIT</a></li>
-                <li><a href="issue.html" target="_blank"></a>ISSUE</a></li>
-                <li><a href="masthead.html" target="_blank">MASTHEAD</a></li>
+                <li><a href="index.html">HOME</a></li>
+                <li><a href="about.html">ABOUT</a></li>
+                <li><a href="submission.html">SUBMIT</a></li>
+                <li><a href="issue.html"></a>ISSUE</a></li>
+                <li><a href="masthead.html">MASTHEAD</a></li>
             </ul>
           </div>
           <i class="fa fa-bars" onclick="showMenu()"></i>
@@ -121,12 +121,12 @@
           <h3>Quick Links</h3>
           <ul>
             <li><a href="index.html" >Home</a></li>
-            <li><a href="about.html" target="_blank">About</a></li>
-            <li><a href="submission.html" target="_blank">Submit</a></li>
-            <li><a href="issue.html" target="_blank">Issue</a></li>
-            <li><a href="masthead.html" target="_blank">Masthead</a></li>
-            <li><a href="faq.html" target="_blank">FAQ</a></li>
-            <li><a href="open-source.html" target="_blank">Open Source</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="submission.html">Submit</a></li>
+            <li><a href="issue.html">Issue</a></li>
+            <li><a href="masthead.html">Masthead</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="open-source.html">Open Source</a></li>
           </ul>
         </div>
         <div class="footer-contact">

--- a/index.html
+++ b/index.html
@@ -37,13 +37,13 @@
           <i class="fa fa-times" onclick="hideMenu()"></i>
           <ul>
 
-            <li><a href="index.html" target="_blank">HOME</a></li>
-            <li><a href="about.html" target="_blank">ABOUT</a></li>
-            <li><a href="submission.html" target="_blank">SUBMIT</a></li>
-            <li><a href="issue.html" target="_blank">ISSUE</a></li>
-            <li><a href="masthead.html" target="_blank">MASTHEAD</a></li>
-            <li><a href="faq.html" target="_blank">FAQ</a></li>
-            <li><a href="open-source.html" target="_blank">OPEN SOURCE</a></li>
+            <li><a href="index.html">HOME</a></li>
+            <li><a href="about.html">ABOUT</a></li>
+            <li><a href="submission.html">SUBMIT</a></li>
+            <li><a href="issue.html">ISSUE</a></li>
+            <li><a href="masthead.html">MASTHEAD</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="open-source.html">OPEN SOURCE</a></li>
 
           </ul>
         </div>
@@ -129,12 +129,12 @@
           <h3>Quick Links</h3>
           <ul>
             <li><a href="index.html" >Home</a></li>
-            <li><a href="about.html" target="_blank">About</a></li>
-            <li><a href="submission.html" target="_blank">Submit</a></li>
-            <li><a href="issue.html" target="_blank">Issue</a></li>
-            <li><a href="masthead.html" target="_blank">Masthead</a></li>
-            <li><a href="faq.html" target="_blank">FAQ</a></li>
-            <li><a href="open-source.html" target="_blank">Open Source</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="submission.html">Submit</a></li>
+            <li><a href="issue.html">Issue</a></li>
+            <li><a href="masthead.html">Masthead</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="open-source.html">Open Source</a></li>
           </ul>
         </div>
         <div class="footer-contact">

--- a/issue.html
+++ b/issue.html
@@ -107,12 +107,12 @@
           <h3>Quick Links</h3>
           <ul>
             <li><a href="index.html" >Home</a></li>
-            <li><a href="about.html" target="_blank">About</a></li>
-            <li><a href="submission.html" target="_blank">Submit</a></li>
-            <li><a href="issue.html" target="_blank">Issue</a></li>
-            <li><a href="masthead.html" target="_blank">Masthead</a></li>
-            <li><a href="faq.html" target="_blank">FAQ</a></li>
-            <li><a href="open-source.html" target="_blank">Open Source</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="submission.html">Submit</a></li>
+            <li><a href="issue.html">Issue</a></li>
+            <li><a href="masthead.html">Masthead</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="open-source.html">Open Source</a></li>
           </ul>
         </div>
         <div class="footer-contact">

--- a/masthead.html
+++ b/masthead.html
@@ -25,11 +25,11 @@
             <i class="fa fa-times" onclick="hideMenu()"></i>
             <ul>
 
-                <li><a href="index.html" target="_blank">HOME</a></li>
-                <li><a href="about.html" target="_blank">ABOUT</a></li>
-                <li><a href="submission.html" target="_blank">SUBMIT</a></li>
-                <li><a href="issue.html" target="_blank">ISSUE</a></li>
-                <li><a href="masthead.html" target="_blank">MASTHEAD</a></li>
+                <li><a href="index.html">HOME</a></li>
+                <li><a href="about.html">ABOUT</a></li>
+                <li><a href="submission.html">SUBMIT</a></li>
+                <li><a href="issue.html">ISSUE</a></li>
+                <li><a href="masthead.html">MASTHEAD</a></li>
 
             </ul>
           </div>
@@ -602,12 +602,12 @@
           <h3>Quick Links</h3>
           <ul>
             <li><a href="index.html" >Home</a></li>
-            <li><a href="about.html" target="_blank">About</a></li>
-            <li><a href="submission.html" target="_blank">Submit</a></li>
-            <li><a href="issue.html" target="_blank">Issue</a></li>
-            <li><a href="masthead.html" target="_blank">Masthead</a></li>
-            <li><a href="faq.html" target="_blank">FAQ</a></li>
-            <li><a href="open-source.html" target="_blank">Open Source</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="submission.html">Submit</a></li>
+            <li><a href="issue.html">Issue</a></li>
+            <li><a href="masthead.html">Masthead</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="open-source.html">Open Source</a></li>
           </ul>
         </div>
         <div class="footer-contact">

--- a/open-source.html
+++ b/open-source.html
@@ -84,12 +84,12 @@
           <h3>Quick Links</h3>
           <ul>
             <li><a href="index.html" >Home</a></li>
-            <li><a href="about.html" target="_blank">About</a></li>
-            <li><a href="submission.html" target="_blank">Submit</a></li>
-            <li><a href="issue.html" target="_blank">Issue</a></li>
-            <li><a href="masthead.html" target="_blank">Masthead</a></li>
-            <li><a href="faq.html" target="_blank">FAQ</a></li>
-            <li><a href="open-source.html" target="_blank">Open Source</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="submission.html">Submit</a></li>
+            <li><a href="issue.html">Issue</a></li>
+            <li><a href="masthead.html">Masthead</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="open-source.html">Open Source</a></li>
           </ul>
         </div>
         <div class="footer-contact">

--- a/submission.html
+++ b/submission.html
@@ -24,12 +24,12 @@
             <i class="fa fa-times" onclick="hideMenu()"></i>
             <ul>
 
-                <li><a href="index.html" target="_blank">HOME</a></li>
-                <li><a href="about.html" target="_blank">ABOUT</a></li>
-                <li><a href="submission.html" target="_blank">SUBMIT</a></li>
-                <li><a href="issue.html" target="_blank">ISSUE</a></li>
-                <li><a href="masthead.html" target="_blank">MASTHEAD</a></li>
-                <li><a href="open-source.html" target="_blank">Open Source</a></li>
+                <li><a href="index.html">HOME</a></li>
+                <li><a href="about.html">ABOUT</a></li>
+                <li><a href="submission.html">SUBMIT</a></li>
+                <li><a href="issue.html">ISSUE</a></li>
+                <li><a href="masthead.html">MASTHEAD</a></li>
+                <li><a href="open-source.html">Open Source</a></li>
 
             </ul>
           </div>
@@ -127,12 +127,12 @@
           <h3>Quick Links</h3>
           <ul>
             <li><a href="index.html" >Home</a></li>
-            <li><a href="about.html" target="_blank">About</a></li>
-            <li><a href="submission.html" target="_blank">Submit</a></li>
-            <li><a href="issue.html" target="_blank">Issue</a></li>
-            <li><a href="masthead.html" target="_blank">Masthead</a></li>
-            <li><a href="faq.html" target="_blank">FAQ</a></li>
-            <li><a href="open-source.html" target="_blank">Open Source</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="submission.html">Submit</a></li>
+            <li><a href="issue.html">Issue</a></li>
+            <li><a href="masthead.html">Masthead</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="open-source.html">Open Source</a></li>
           </ul>
         </div>
         <div class="footer-contact">


### PR DESCRIPTION
## Contributor Info  
**Your Name:** Aashi Garg

---

## Related Issue  
Fixes: #107

---

## Description  
- Removed `target="_blank"` from internal navigation bar options.  
- This improves overall user experience by preventing unnecessary new tabs from opening when navigating within the website.  
- External links (like PDFs or third-party websites) will still open in new tabs for convenience and context preservation.

---

## Screenshots / Video (Before & After)

### Before:  
- Clicking on any navbar option opened the link in a new tab.  
![Before video](https://github.com/user-attachments/assets/4de4c13d-65c7-49a1-8050-8ba1b2aa5e9c)

### After:  
- Internal links now open in the same tab.  
- External links (like PDFs or other websites) still open in new tabs.  
![After video](https://github.com/user-attachments/assets/599fe9db-37a0-4bc5-9084-3cd92299f04b)

---

## Checklist  
- [x] Mentioned the issue number in this PR.  
- [x] Created a separate branch (not `main`) before committing.  
- [x] Changes tested and verified.  
- [x] Attached necessary screenshots/videos for clarity.  
- [x] Code is clean, readable, and commented where necessary.  
- [x] No merge conflicts.  
- [x] Follows the design/style guide of the project.  
- [x] Added contributor name above.  
- [x] Confirmed that the feature fits well with the latest updated version of the website.

---

## Extra Notes (Optional)  
Thanks for reviewing this PR!
