### PR TITLE
Add dark/light mode toggle and consistent navbar styles

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,8 +10,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@1,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-    />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
+    <link rel="stylesheet" href="styles/theme.css">
 </head>
 <body>
     <div class="progress-container">
@@ -19,6 +19,8 @@
     </div>
     <section class="header">
         <nav>
+          <button id="theme-toggle" style="margin-left: auto;">🌙</button>
+
           <div class = "nav-links" id="navLinks">
             <i class="fa fa-times" onclick="hideMenu()"></i>
             <ul>
@@ -176,6 +178,23 @@
    
 
 <script src="index.js"></script>
+<script>
+  const toggle = document.getElementById('theme-toggle');
+  const storedTheme = localStorage.getItem('theme');
+
+  if (storedTheme) {
+    document.documentElement.setAttribute('data-theme', storedTheme);
+    toggle.textContent = storedTheme === 'dark' ? '☀️' : '🌙';
+  }
+
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    toggle.textContent = next === 'dark' ? '☀️' : '🌙';
+  });
+</script>
 
 
 </body>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />
-
+<link rel="stylesheet" href="styles/theme.css">
   </head>
   <body>
     <div class="progress-container">
@@ -33,6 +33,7 @@
     </div>
     <section class="header">
       <nav role="navigation" aria-label="Main Menu">
+        <button id="theme-toggle" style="margin-left: auto;">🌙</button>
         <div class="nav-links" id="navLinks">
           <i class="fa fa-times" onclick="hideMenu()"></i>
           <ul>
@@ -172,5 +173,23 @@
     </footer>
 
     <script src="index.js"></script>
+    <script>
+  const toggle = document.getElementById('theme-toggle');
+  const storedTheme = localStorage.getItem('theme');
+
+  if (storedTheme) {
+    document.documentElement.setAttribute('data-theme', storedTheme);
+    toggle.textContent = storedTheme === 'dark' ? '☀️' : '🌙';
+  }
+
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    toggle.textContent = next === 'dark' ? '☀️' : '🌙';
+  });
+</script>
+
   </body>
 </html>

--- a/issue.html
+++ b/issue.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@1,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-
+<link rel="stylesheet" href="styles/theme.css">
 </head>
 <body>
     <div class="progress-container">
@@ -18,6 +18,7 @@
     </div>
     <section class="header">
         <nav>
+          <button id="theme-toggle" style="margin-left: auto;">🌙</button>
           <div class = "nav-links" id="navLinks">
             <i class="fa fa-times" onclick="hideMenu()"></i>
             <ul>
@@ -138,5 +139,23 @@
       </div>
     </footer>    
     <script src="index.js"></script>
+    <script>
+  const toggle = document.getElementById('theme-toggle');
+  const storedTheme = localStorage.getItem('theme');
+
+  if (storedTheme) {
+    document.documentElement.setAttribute('data-theme', storedTheme);
+    toggle.textContent = storedTheme === 'dark' ? '☀️' : '🌙';
+  }
+
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    toggle.textContent = next === 'dark' ? '☀️' : '🌙';
+  });
+</script>
+
 </body>
 </html>

--- a/masthead.html
+++ b/masthead.html
@@ -6,6 +6,7 @@
     <title>Masthead</title>
     <link rel="stylesheet" href="masthead.css">
     <!-- <link rel="stylesheet" href="style.css"> -->
+     
     <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Crimson+Text:ital,wght@1,700&display=swap" rel="stylesheet">
@@ -13,14 +14,18 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />
+    <link rel="stylesheet" href="styles/theme.css">
 </head>
-<body>
+    <body class="no-dark-text">
+
     <div class="progress-container">
       <div class="progress-bar" id="progressBar"></div>
     </div>
     
     <section class="header">
         <nav>
+            <button id="theme-toggle" style="margin-left: auto;">🌙</button>
+
           <div class = "nav-links" id="navLinks">
             <i class="fa fa-times" onclick="hideMenu()"></i>
             <ul>
@@ -645,6 +650,23 @@
     </footer>
 
     <script src="index.js" ></script>
+<script>
+  const toggle = document.getElementById('theme-toggle');
+  const storedTheme = localStorage.getItem('theme');
+
+  if (storedTheme) {
+    document.documentElement.setAttribute('data-theme', storedTheme);
+    toggle.textContent = storedTheme === 'dark' ? '☀️' : '🌙';
+  }
+
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    toggle.textContent = next === 'dark' ? '☀️' : '🌙';
+  });
+</script>
 
 </body>
 </html>

--- a/open-source.html
+++ b/open-source.html
@@ -16,6 +16,7 @@
     integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
     crossorigin="anonymous"
     referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="styles/theme.css">
 </head>
 
 <body>
@@ -27,6 +28,8 @@
   <!-- Navbar -->
   <section class="header">
     <nav>
+      <button id="theme-toggle" style="margin-left: auto;">🌙</button>
+
       <div class="nav-links" id="navLinks">
         <i class="fa fa-times" onclick="hideMenu()"></i>
         <ul>
@@ -151,6 +154,24 @@
       document.body.style.overflow = "auto";
     }
   </script>
+  <script>
+  const toggle = document.getElementById('theme-toggle');
+  const storedTheme = localStorage.getItem('theme');
+
+  if (storedTheme) {
+    document.documentElement.setAttribute('data-theme', storedTheme);
+    toggle.textContent = storedTheme === 'dark' ? '☀️' : '🌙';
+  }
+
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    toggle.textContent = next === 'dark' ? '☀️' : '🌙';
+  });
+</script>
+
 </body>
 
 </html>

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,151 @@
+/* 🌞 LIGHT MODE: Cream + Deep Red */
+:root {
+  --bg-color: #fdf0d5;
+  --text-color: #1a1a1a;
+  --link-color: #780000;
+  --accent-color: #780000;
+  --nav-bg: rgba(163, 163, 163, 0.16);
+  --nav-text-color: #fdf0d5;
+  --header-bg: #fde74c40;
+  --progress-bg: #EAE0D5;
+  --progress-bar: #780000;
+}
+
+/* 🌚 DARK MODE: Deep Red Accent + Soft Contrast */
+[data-theme="dark"] {
+  --bg-color: #121212;
+  --text-color: #fdf0d5;
+  --link-color: #ffcccb;
+  --accent-color: #780000;
+  --nav-bg: rgba(30, 30, 30, 0.95);
+  --nav-text-color: #fdf0d5;
+  --header-bg: #1f1f1f;
+  --progress-bg: #2c2c2c;
+  --progress-bar: #780000;
+}
+
+/* General Layout */
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+  line-height: 1.6;
+}
+
+/* Navbar */
+nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 5%;
+  background: var(--nav-bg);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+  position: fixed;
+  top: 0;
+  height: 6%;
+  width: 100%;
+  z-index: 999;
+}
+
+.nav-links ul li {
+  list-style: none;
+  display: inline-block;
+  padding: 8px 12px;
+  position: relative;
+}
+
+.nav-links ul li a {
+  color: var(--nav-text-color);
+  text-decoration: none;
+  font-family: serif;
+  font-size: 13px;
+  padding: 12px 16px;
+  display: block;
+}
+
+.nav-links ul li::after {
+  content: '';
+  width: 0%;
+  height: 2px;
+  background: var(--accent-color);
+  display: block;
+  margin: auto;
+  transition: 0.5s;
+}
+
+.nav-links ul li:hover::after {
+  width: 100%;
+}
+
+/* Header */
+.header,
+.header1 {
+  background-color: var(--header-bg);
+}
+h1 {
+  color: #7b1113 !important;
+}
+/* Hero Text */
+.text-box1 {
+  color: var(--accent-color);
+  font-family: "Crimson Text", serif;
+  width: 90%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+}
+
+.text-box1 h1 {
+  margin-top: 15px;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 62px;
+}
+
+.text-box1 p {
+  margin: 10px 0 40px;
+  font-size: 20px;
+}
+
+/* Progress Bar */
+.progress-container {
+  width: 100%;
+  height: 4px;
+  background: var(--progress-bg);
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+}
+
+.progress-bar {
+  height: 100%;
+  width: 0%;
+  background: var(--progress-bar);
+}
+
+/* Links */
+a {
+  color: var(--link-color);
+  transition: 0.3s;
+}
+/* Apply cream text only if body does NOT have class no-dark-text */
+/*[data-theme="dark"]:not(.no-dark-text) p,*/
+[data-theme="dark"] body:not(.no-dark-text) p,
+[data-theme="dark"] body:not(.no-dark-text) li,
+[data-theme="dark"] body:not(.no-dark-text) span,
+[data-theme="dark"] body:not(.no-dark-text) div,
+[data-theme="dark"] body:not(.no-dark-text) h1,
+[data-theme="dark"] body:not(.no-dark-text) h2,
+[data-theme="dark"] body:not(.no-dark-text) h3,
+[data-theme="dark"] body:not(.no-dark-text) h4,
+[data-theme="dark"] body:not(.no-dark-text) h5,
+[data-theme="dark"] body:not(.no-dark-text) h6 {
+  color: #fdf0d5 !important;
+}
+

--- a/submission.html
+++ b/submission.html
@@ -13,6 +13,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />
+    <link rel="stylesheet" href="styles/theme.css">
 </head>
 <body>
     <div class="progress-container">
@@ -20,6 +21,7 @@
     </div>
     <section class="header">
         <nav>
+          <button id="theme-toggle" style="margin-left: auto;">🌙</button>
           <div class = "nav-links" id="navLinks">
             <i class="fa fa-times" onclick="hideMenu()"></i>
             <ul>
@@ -171,6 +173,23 @@
 
 
     <script src="index.js" ></script>
+    <script>
+  const toggle = document.getElementById('theme-toggle');
+  const storedTheme = localStorage.getItem('theme');
+
+  if (storedTheme) {
+    document.documentElement.setAttribute('data-theme', storedTheme);
+    toggle.textContent = storedTheme === 'dark' ? '☀️' : '🌙';
+  }
+
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    toggle.textContent = next === 'dark' ? '☀️' : '🌙';
+  });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
### Changes Made:
- Added a dark/light mode toggle with theme persistence
- Fixed inconsistent navbar styles across pages
- Ensured masthead.html retains black text in dark mode
- h1 headings retain dark red color in all modes

### Related Issue(s):
Fixes #130   
