### PR TITLE
fix: remove console.log flooding in scroll event listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ loginBtn.addEventListener('click', () => {
 
 // to show and hide the back-to-top button
 window.addEventListener("scroll", () => {
-    if (window.pageYOffset > 300) { console.log(window.pageYOffset);
+    if (window.pageYOffset > 300) {
         backToTop.classList.add("active");
     } else {
         backToTop.classList.remove("active");


### PR DESCRIPTION
Fixes #173

## Changes Made
- Removed `console.log(window.pageYOffset)` from the scroll event listener
- This eliminates the console spam that occurred on every scroll event
- All existing functionality (back-to-top button) remains intact

## Testing
- Back-to-top button still works as expected
- Console no longer floods with pageYOffset logs during scrolling