### PR TITLE
Fix: Removed duplicate underline on navbar links across all pages

### DIFF
--- a/about.css
+++ b/about.css
@@ -100,8 +100,7 @@ font-size: 20px
     display: block;
 }
 .nav-links ul li a:hover {
-    text-decoration: underline;
-    transition: 0.3s ease;
+    text-decoration: none; /* REMOVE underline */
 }
 
 .nav-links ul li::after {

--- a/faq.css
+++ b/faq.css
@@ -101,22 +101,25 @@ nav{
   padding: 12px 16px;
   display: block;
 }
-.nav-links ul li::after {
-  content: "";
-  width: 0%;
-  height: 2px;
-  background: #fdf0d5;
-  display: block;
-  margin: auto;
-  transition: 0.5s;
-}
+
 .nav-links ul li a:hover {
-  text-decoration: underline;
-  transition: 0.3s ease;
+    text-decoration: none; /* REMOVE underline */
 }
+
+.nav-links ul li::after {
+    content: '';
+    width: 0%;
+    height: 2px;
+    background: #fdf0d5;
+    display: block;
+    margin: auto;
+    transition: 0.5s;
+}
+
 .nav-links ul li:hover::after {
-  width: 100%;
+    width: 100%;
 }
+
 
 nav .fa {
   display: none;

--- a/issue.css
+++ b/issue.css
@@ -109,10 +109,10 @@ font-size: 20px
     padding: 12px 16px;
     display: block;
 }
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+    text-decoration: none; /* REMOVE underline */
 }
+
 .nav-links ul li::after {
     content: '';
     width: 0%;
@@ -126,6 +126,7 @@ font-size: 20px
 .nav-links ul li:hover::after {
     width: 100%;
 }
+
 
 nav .fa {
     display: none;

--- a/masthead.css
+++ b/masthead.css
@@ -133,22 +133,25 @@ nav{
   padding: 12px 16px;
   display: block;
 }
-.nav-links ul li::after {
-  content: "";
-  width: 0%;
-  height: 2px;
-  background: #fdf0d5;
-  display: block;
-  margin: auto;
-  transition: 0.5s;
-}
+
 .nav-links ul li a:hover {
-  text-decoration: underline;
-  transition: 0.3s ease;
+    text-decoration: none; /* REMOVE underline */
 }
+
+.nav-links ul li::after {
+    content: '';
+    width: 0%;
+    height: 2px;
+    background: #fdf0d5;
+    display: block;
+    margin: auto;
+    transition: 0.5s;
+}
+
 .nav-links ul li:hover::after {
-  width: 100%;
+    width: 100%;
 }
+
 
 nav .fa {
   display: none;

--- a/style.css
+++ b/style.css
@@ -109,9 +109,8 @@ nav {
 
 }
 
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+    text-decoration: none; /* REMOVE underline */
 }
 
 .nav-links ul li::after {
@@ -127,6 +126,7 @@ nav {
 .nav-links ul li:hover::after {
     width: 100%;
 }
+
 
 nav .fa {
     display: none;

--- a/submission.css
+++ b/submission.css
@@ -108,22 +108,22 @@ nav {
   padding: 12px 16px;
   display: block;
 }
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+    text-decoration: none; /* REMOVE underline */
 }
+
 .nav-links ul li::after {
-  content: "";
-  width: 0%;
-  height: 2px;
-  background: #fdf0d5;
-  display: block;
-  margin: auto;
-  transition: 0.5s;
+    content: '';
+    width: 0%;
+    height: 2px;
+    background: #fdf0d5;
+    display: block;
+    margin: auto;
+    transition: 0.5s;
 }
 
 .nav-links ul li:hover::after {
-  width: 100%;
+    width: 100%;
 }
 
 nav .fa {


### PR DESCRIPTION
## Contributor Info
**Your Name:**  
Manali lamture

---

## Related Issue
Fixes: #305

---

## Description
This PR resolves the issue where each navbar item showed two underlines:
- One from `text-decoration: underline` on `<a>`
- One from `::after` animation

The CSS `text-decoration: underline` was removed from the hover state,
so only the smooth animated underline remains.

Fixes #<issue-number>


---

## Screenshots / Video (Before & After)
### Before:
<img width="464" height="61" alt="Screenshot 2025-07-31 110349" src="https://github.com/user-attachments/assets/4c8e94fb-6250-4afa-9517-0c6d49ce0ceb" />


### After:
<img width="363" height="51" alt="image" src="https://github.com/user-attachments/assets/f6157209-0410-4485-8cfb-e8f119f03e82" />

---

