### PR TITLE
Fix: Remove duplicate underlines in navbar

### DIFF
--- a/about.css
+++ b/about.css
@@ -1,155 +1,153 @@
-
-*{
-margin: 0;
-padding: 0;
-box-sizing: border-box;
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
-body{
-background-color: #fdf0d5;
-line-height: 1.6;
+body {
+  background-color: #fdf0d5;
+  line-height: 1.6;
 }
 
 .progress-container {
   width: 100%;
-  height: 4px; 
-  background: #EAE0D5; 
-  position: fixed; 
+  height: 4px;
+  background: #eae0d5;
+  position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000; 
+  z-index: 1000;
 }
 
 .progress-bar {
   height: 100%;
-  width: 0%; 
-  background: #8B0000; 
+  width: 0%;
+  background: #8b0000;
 }
 
-.header{
-    background-color: #fde74c40;
+.header {
+  background-color: #fde74c40;
 }
 .header1 {
-min-height: 26vh;
-width: 100%;
-background-color: #fdf0d5;
-background-position: center;
-background-size: cover;
-position: relative;
-padding: 20px 0;
-margin-top: 40px;
+  min-height: 26vh;
+  width: 100%;
+  background-color: #fdf0d5;
+  background-position: center;
+  background-size: cover;
+  position: relative;
+  padding: 20px 0;
+  margin-top: 40px;
 }
 
 nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 5%;
-    margin-right: 6px;
-    background: #780000; /* Solid maroon background */
-    backdrop-filter: none; /* Optional: disable the blur if no longer needed */
-    -webkit-backdrop-filter: none; /* Optional: same for Safari */
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-    border-bottom: 1px solid rgba(179, 177, 177, 0.2);
-    position: fixed;
-    top: 0;
-    height: 9%;
-    width: 100%;
-    z-index: 999;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 5%;
+  margin-right: 6px;
+  background: #780000; /* Solid maroon background */
+  backdrop-filter: none; /* Optional: disable the blur if no longer needed */
+  -webkit-backdrop-filter: none; /* Optional: same for Safari */
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+  position: fixed;
+  top: 0;
+  height: 9%;
+  width: 100%;
+  z-index: 999;
 }
 
 .text-box1 {
-color: #780000;
-font-family:"Crimson Text", serif;
-width: 90%;
-position: absolute;
-top: 50%;
-left: 50%;
-transform: translate(-50%, -50%);
-text-align: center;
+  color: #780000;
+  font-family: "Crimson Text", serif;
+  width: 90%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
 }
 
 .text-box1 h1 {
-margin-top: 15px;
-font-weight: 700;
-font-style: italic;
-font-size: 62px;
+  margin-top: 15px;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 62px;
 }
 .text-box1 p {
-margin: 10px 0 40px;
-font-size: 20px   
+  margin: 10px 0 40px;
+  font-size: 20px;
 }
 .nav-links {
-    flex: 1;
-    text-align: right;
+  flex: 1;
+  text-align: right;
 }
 
 .nav-links ul li {
-    list-style: none;
-    display: inline-block;
-    padding: 8px 12px;
-    position: relative;
+  list-style: none;
+  display: inline-block;
+  padding: 8px 12px;
+  position: relative;
 }
 
-.nav-links ul li a{
-    color: #fdf0d5;
-    text-decoration: none;
-    font-family: serif;
-    font-size: 13px;
-    padding: 12px 16px;
-    display: block;
+.nav-links ul li a {
+  color: #fdf0d5;
+  text-decoration: none;
+  font-family: serif;
+  font-size: 13px;
+  padding: 12px 16px;
+  display: block;
 }
 .nav-links ul li a:hover {
-    text-decoration: underline;
-    transition: 0.3s ease;
+  transition: 0.3s ease;
 }
 
 .nav-links ul li::after {
-    content: '';
-    width: 0%;
-    height: 2px;
-    background: #fdf0d5;
-    display: block;
-    margin: auto;
-    transition: 0.5s;
+  content: "";
+  width: 0%;
+  height: 2px;
+  background: #fdf0d5;
+  display: block;
+  margin: auto;
+  transition: 0.5s;
 }
 
 .nav-links ul li:hover::after {
-    width: 100%;
+  width: 100%;
 }
 
 nav .fa {
-    display: none;
+  display: none;
 }
 
-@media(max-width: 700px) {
-    .nav-links ul li {
-        display: block;
-    }
+@media (max-width: 700px) {
+  .nav-links ul li {
+    display: block;
+  }
 
-    .nav-links ul li a {
-       color: #fdf0d5;
-       display: block;
-       padding: 12px 16px;
-       text-decoration: none;
-       border-bottom: 1px solid rgba(249, 249, 249, 0.795); /* divider */
-    }
+  .nav-links ul li a {
+    color: #fdf0d5;
+    display: block;
+    padding: 12px 16px;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(249, 249, 249, 0.795); /* divider */
+  }
 
-    .nav-links {
-        position: fixed;
-        background: #780000; /* solid color improves contrast */
-        height: 100vh;
-        width: 200px;
-        top: 0;
-        right: -200px;
-        text-align: left;
-        z-index: 2;
-        transition: 1s;
-        box-shadow: -4px 0 10px rgba(0, 0, 0, 0.5); /* adds depth */
-        border-left: 2px solid #d02f2f; /* optional: edge highlight */
-    }
+  .nav-links {
+    position: fixed;
+    background: #780000; /* solid color improves contrast */
+    height: 100vh;
+    width: 200px;
+    top: 0;
+    right: -200px;
+    text-align: left;
+    z-index: 2;
+    transition: 1s;
+    box-shadow: -4px 0 10px rgba(0, 0, 0, 0.5); /* adds depth */
+    border-left: 2px solid #d02f2f; /* optional: edge highlight */
+  }
 
-    nav .fa-times {
+  nav .fa-times {
     display: block;
     color: #fdf0d5;
     margin: 10px;
@@ -158,24 +156,24 @@ nav .fa {
   }
   nav .fa-bars {
     display: block;
-    color: #fdf0d5; 
+    color: #fdf0d5;
     margin: 10px;
     font-size: 22px;
     cursor: pointer;
   }
-    .nav-links ul{
-        padding: 30px;
-    }
-    }
-     /* clickable cards */
-    .landmarkCard{
-    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-    background-color: #780000;
-    border-radius: 10px;
-    width: 300px;
-    transition: transform 0.2s ease;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
+  .nav-links ul {
+    padding: 30px;
+  }
+}
+/* clickable cards */
+.landmarkCard {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: #780000;
+  border-radius: 10px;
+  width: 300px;
+  transition: transform 0.2s ease;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 .landmarkCard:hover {
   transform: scale(1.05);
@@ -185,28 +183,28 @@ nav .fa {
   height: auto;
   border-radius: 10px;
 }
-.landmarkButton{
-    background-color: #fdf0d5;
-    color: #780000;
-    border-radius: 10px;
-    padding: 0.5rem;
-    margin-top: -1rem;
-    margin-bottom: 1rem;
-    font-weight: 600;
-    font-size: 13px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    position:relative;
+.landmarkButton {
+  background-color: #fdf0d5;
+  color: #780000;
+  border-radius: 10px;
+  padding: 0.5rem;
+  margin-top: -1rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+  font-size: 13px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  position: relative;
 }
 .landmarkButton:hover {
-    background: linear-gradient(135deg, #fddf9b, #fcbf49);
-    color: #5a0000;
-    transform: scale(1.08) translateY(-2px);
-    text-shadow: 0 0 3px #fff0d0, 0 0 6px #ffc300;
-    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2);
-    cursor: pointer;
+  background: linear-gradient(135deg, #fddf9b, #fcbf49);
+  color: #5a0000;
+  transform: scale(1.08) translateY(-2px);
+  text-shadow: 0 0 3px #fff0d0, 0 0 6px #ffc300;
+  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
 }
 
-@media(max-width: 700px){
+@media (max-width: 700px) {
   .landmarkButton {
     font-size: 13px;
     padding: 10px 16px;
@@ -216,209 +214,204 @@ nav .fa {
   }
 }
 
-
-
-@media(max-width: 700px) {
-.text-box h1 {
-margin-top: 15px;
-font-weight: 700;
-font-style: italic;
-font-size: 40px;
-}
+@media (max-width: 700px) {
+  .text-box h1 {
+    margin-top: 15px;
+    font-weight: 700;
+    font-style: italic;
+    font-size: 40px;
+  }
 }
 
 .Introductory {
-width: 80%;
-margin: auto;
-text-align: center;
-padding-top: 20px;
+  width: 80%;
+  margin: auto;
+  text-align: center;
+  padding-top: 20px;
 }
 
 #intro1 {
-color: #111717;
-font-size: 19px;
-font-weight: 300;
-line-height: 30px;
-padding: 10px;
-font-style: italic;
-font-family: 'Times New Roman', Times, serif;
+  color: #111717;
+  font-size: 19px;
+  font-weight: 300;
+  line-height: 30px;
+  padding: 10px;
+  font-style: italic;
+  font-family: "Times New Roman", Times, serif;
 }
-.bold-words{
-   font-weight: bold;
+.bold-words {
+  font-weight: bold;
 }
-.underline-words{
+.underline-words {
   text-decoration: underline;
 }
-#CardsHeading{
-    color : #780000;
-    font-size: 25px;
-    margin : 10px;
+#CardsHeading {
+  color: #780000;
+  font-size: 25px;
+  margin: 10px;
 }
 
-
-.landmarks{
-    display: flex;
-    justify-content: center;
-    width: 95%;
-    margin: auto;
-    text-align: center;
-    padding-top: 50px;
-    background-color: #ffd9e7;
-    border-radius: 10px;
-    flex-wrap: wrap;
+.landmarks {
+  display: flex;
+  justify-content: center;
+  width: 95%;
+  margin: auto;
+  text-align: center;
+  padding-top: 50px;
+  background-color: #ffd9e7;
+  border-radius: 10px;
+  flex-wrap: wrap;
 }
-.landmarkCard{
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    height: 380px;
-    margin :25px;
+.landmarkCard {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 380px;
+  margin: 25px;
 }
-.landmarkCard img{
-    width: 100%;
-    height: 200px;
-    object-fit: cover;
-    border-top-left-radius: 10px;
-    border-top-right-radius: 10px;
+.landmarkCard img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
 }
 .landmarks {
-    background-color: #fdf0d5;
-    padding: 50px 20px;
-    text-align: center;
+  background-color: #fdf0d5;
+  padding: 50px 20px;
+  text-align: center;
 }
 .Tag-line {
-    color:whitesmoke;
-    text-align: center;
-    font-family:'Times New Roman', Times, serif;
-    font-style:italic;
+  color: whitesmoke;
+  text-align: center;
+  font-family: "Times New Roman", Times, serif;
+  font-style: italic;
 }
-@media(max-width: 700px) {
-.Tag-line {
-margin-top: 15px;
-padding: 8px;
-font-weight: 700;
-font-style: italic;
-font-size: 15px;
-line-height: 1.3;
-word-wrap: break-word;
-}
-}
-.landmarks h2 {
-    font-size: 20px;
-    color: #fdf0d5;
-    margin-bottom: 30px;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-}
-
-.layer {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: rgba(120, 0, 0, 0.8);
-    color: #fff;
-    padding: 15px;
-    text-align: center;
-    font-size: 1.2em;
-    transition: background 0.3s ease;
-}
-
-.layer h3 {
-    margin: 0;
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-}
-
-h2 {
-    text-align: center;
-    color: #fdf0d5;
+@media (max-width: 700px) {
+  .Tag-line {
+    margin-top: 15px;
+    padding: 8px;
     font-weight: 700;
     font-style: italic;
     font-size: 15px;
-    padding-top: 1rem;
-} 
+    line-height: 1.3;
+    word-wrap: break-word;
+  }
+}
+.landmarks h2 {
+  font-size: 20px;
+  color: #fdf0d5;
+  margin-bottom: 30px;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.layer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(120, 0, 0, 0.8);
+  color: #fff;
+  padding: 15px;
+  text-align: center;
+  font-size: 1.2em;
+  transition: background 0.3s ease;
+}
+
+.layer h3 {
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+h2 {
+  text-align: center;
+  color: #fdf0d5;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 15px;
+  padding-top: 1rem;
+}
 
 .h32 {
-    text-align: center;
-    color: #780000;
+  text-align: center;
+  color: #780000;
 }
 
 .layer:hover {
-    background: rgba(226,0,0,0.4);
+  background: rgba(226, 0, 0, 0.4);
 }
 
 .h32 {
-    text-align: center;
-    color: #780000;
+  text-align: center;
+  color: #780000;
 }
 
 .layer:hover {
-    background: rgba(226,0,0,0.4);
+  background: rgba(226, 0, 0, 0.4);
 }
-
 
 @media (max-width: 600px) {
-    .landmarks h2 {
-        font-size: 1.2em;
-    }
-    .landmark-col img {
-        height: 180px;
-    }
-    .layer {
-        font-size: 1em;
-        padding: 10px;
-    }
+  .landmarks h2 {
+    font-size: 1.2em;
+  }
+  .landmark-col img {
+    height: 180px;
+  }
+  .layer {
+    font-size: 1em;
+    padding: 10px;
+  }
 }
-
 
 .site-footer {
   background: #7a0000;
   color: #f9f9e6;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
   padding: 50px 20px 15px;
 }
 
 /* Back-to-top button */
 .back-to-top {
-    position: fixed;
-    height: 45px;
-    width: 45px;
-    bottom: 16px;
-    right: 30px;
-    font-size: 26px;
-    background-color: #780000;
-    color: #fdf0d5;
-    border-radius: 50%;;
-    text-decoration: none;
-    display: flex;
-    opacity: 0;
-    pointer-events: none;
-    justify-content: center;
-    align-items: center;
-    box-shadow: 0px 0px 10px #fdf0d5;
-    transition: all .4s;
+  position: fixed;
+  height: 45px;
+  width: 45px;
+  bottom: 16px;
+  right: 30px;
+  font-size: 26px;
+  background-color: #780000;
+  color: #fdf0d5;
+  border-radius: 50%;
+  text-decoration: none;
+  display: flex;
+  opacity: 0;
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 0px 10px #fdf0d5;
+  transition: all 0.4s;
 }
 
 .back-to-top.active {
-    bottom: 30px;
-    opacity: 1;
-    pointer-events: auto;
+  bottom: 30px;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .back-to-top:focus {
-    outline:none;
+  outline: none;
 }
 
 .back-to-top:hover {
-    background-color: #fdf0d5;
-    color: #780000;
-    box-shadow: 0px 0px 10px #780000;
-    font-size: 28px;
+  background-color: #fdf0d5;
+  color: #780000;
+  box-shadow: 0px 0px 10px #780000;
+  font-size: 28px;
 }
 
 /* Top section */
 .footer-top {
   display: grid;
-  justify-content:center ;
+  justify-content: center;
   grid-template-columns: 28% 10% 13% 30%;
   gap: 40px;
   margin-bottom: 100px;
@@ -487,7 +480,7 @@ h2 {
   font-size: 18px;
   color: #fff8e7;
   margin-bottom: 10px;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
 }
 
 .subscription-box form {
@@ -501,7 +494,7 @@ h2 {
   border-radius: 15px;
   margin-bottom: 10px;
 }
-  
+
 .subscription-box button {
   background: #ffcc66;
   color: #7a0000;
@@ -556,47 +549,47 @@ button:active {
 }
 
 .fa-heart {
-    color: #fdf0d5;
-    font-size: 15px;
+  color: #fdf0d5;
+  font-size: 15px;
 }
 
 .icons {
-    color: #fdf0d5;
-    margin: 0 13px;
-    cursor: pointer;
-    padding: 18px 0;
-    width: 35%;
+  color: #fdf0d5;
+  margin: 0 13px;
+  cursor: pointer;
+  padding: 18px 0;
+  width: 35%;
 }
 
 .icons a {
-    color: #fdf0d5;
-    font-size: 25px;
-    padding : 10px;
-} 
+  color: #fdf0d5;
+  font-size: 25px;
+  padding: 10px;
+}
 #insta:hover {
-    color: #ff04c0;
-    text-shadow: 0px 0px 3px#fdf0d5;
-    font-size: 25px;
-    padding : 10px;
-} 
+  color: #ff04c0;
+  text-shadow: 0px 0px 3px #fdf0d5;
+  font-size: 25px;
+  padding: 10px;
+}
 #linkedin:hover {
-    color: #215a8f;
-    text-shadow: 1px 1px 5px#fdf0d5;
-    font-size: 25px;
-    padding : 10px;
-} 
+  color: #215a8f;
+  text-shadow: 1px 1px 5px #fdf0d5;
+  font-size: 25px;
+  padding: 10px;
+}
 #twitter:hover {
-    color: #141414;
-    text-shadow: 1px 1px 5px#fdf0d5;
-    font-size: 25px;
-    padding : 10px;
-} 
+  color: #141414;
+  text-shadow: 1px 1px 5px #fdf0d5;
+  font-size: 25px;
+  padding: 10px;
+}
 #tumblr:hover {
-    color: #3c487c;
-    text-shadow: 1px 1px 5px#fdf0d5;
-    font-size: 25px;
-    padding : 10px;
-} 
+  color: #3c487c;
+  text-shadow: 1px 1px 5px #fdf0d5;
+  font-size: 25px;
+  padding: 10px;
+}
 
 .footer-bottom {
   text-align: center;
@@ -635,7 +628,7 @@ button:active {
   font-size: 18px;
   color: #fff8e7;
   margin-bottom: 10px;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
 }
 
 .subscription-box form {
@@ -649,7 +642,7 @@ button:active {
   border-radius: 15px;
   margin-bottom: 10px;
 }
-  
+
 .subscription-box button {
   background: #ffcc66;
   color: #7a0000;
@@ -665,4 +658,3 @@ button:active {
 .subscription-box button:hover {
   background: #e6b85c;
 }
-

--- a/faq.css
+++ b/faq.css
@@ -3,7 +3,7 @@
   margin: 0;
   box-sizing: border-box;
 }
-.body{
+.body {
   background-color: #fdf0d5;
 }
 html {
@@ -11,21 +11,21 @@ html {
 }
 .progress-container {
   width: 100%;
-  height: 4px; 
-  background: #EAE0D5; 
-  position: fixed; 
+  height: 4px;
+  background: #eae0d5;
+  position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000; 
+  z-index: 1000;
 }
 
 .progress-bar {
   height: 100%;
-  width: 0%; 
-  background: #8B0000; 
+  width: 0%;
+  background: #8b0000;
 }
-.faq-page .header{
-    min-height:20vh;
+.faq-page .header {
+  min-height: 20vh;
 }
 .header {
   min-height: 0vh;
@@ -52,7 +52,7 @@ nav {
   top: 0;
   height: 6%;
   width: 100%;
-  z-index: 999; 
+  z-index: 999;
 }
 nav {
   display: flex;
@@ -71,14 +71,14 @@ nav {
   top: 0;
   height: 6%;
   width: 100%;
-  z-index: 999; 
+  z-index: 999;
 }
-nav{
-    display: flex;
-    background-color: #780000;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0px 5%;
+nav {
+  display: flex;
+  background-color: #780000;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0px 5%;
 }
 
 .nav-links {
@@ -111,7 +111,6 @@ nav{
   transition: 0.5s;
 }
 .nav-links ul li a:hover {
-  text-decoration: underline;
   transition: 0.3s ease;
 }
 .nav-links ul li:hover::after {
@@ -156,21 +155,21 @@ nav .fa {
   }
 }
 
-main{
-    display: flex;
-    gap: 1rem;
-    flex-direction: column;
+main {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
 }
-.heading{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 5rem;
-    background-color: #780000;
-    color: #fdf0d5;
-    text-align: center;
-    font-size: 1.5rem;
-    /* width: 100vw; */
+.heading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 5rem;
+  background-color: #780000;
+  color: #fdf0d5;
+  text-align: center;
+  font-size: 1.5rem;
+  /* width: 100vw; */
 }
 
 .social-icons {
@@ -189,7 +188,6 @@ main{
   transform: translateY(-3px) scale(1.15);
 }
 
-
 .faq {
   color: #780000;
   border-left: 4px solid #780000;
@@ -199,51 +197,49 @@ main{
   margin-right: 5vw;
   padding: 0.5rem;
 }
-a{
-    text-decoration: none;
-    color: #780000;
+a {
+  text-decoration: none;
+  color: #780000;
 }
-.ask{
-    display: flex;
-    color: #fdf0d5;
-    flex-direction: column;
-    height: 10rem;
-    background-color: #780000;
-    width: 25rem;
-    margin: auto;
-    align-items: center;
-    gap: 0.5rem ;   
-    border-radius: 1rem; 
-}
-
-.mail{
-    background-color: #fdf0d5;
-    width: 80%;
-    border-radius: 1.5rem;
-    text-align: center;
-    padding: 0.5rem;
-}
-.ask h3{
-    font-size: 1.5rem;
-}
-.seperator{
-    height: 2rem;
-}
-.ask p{
-    justify-self: end;
-}
-.mail img{
-    object-fit: cover;
+.ask {
+  display: flex;
+  color: #fdf0d5;
+  flex-direction: column;
+  height: 10rem;
+  background-color: #780000;
+  width: 25rem;
+  margin: auto;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 1rem;
 }
 
+.mail {
+  background-color: #fdf0d5;
+  width: 80%;
+  border-radius: 1.5rem;
+  text-align: center;
+  padding: 0.5rem;
+}
+.ask h3 {
+  font-size: 1.5rem;
+}
+.seperator {
+  height: 2rem;
+}
+.ask p {
+  justify-self: end;
+}
+.mail img {
+  object-fit: cover;
+}
 
-
-/*  CSS for Phone */
-@media screen and (max-width:768px) {
-    .heading{
-        font-size: 0.75rem;
-    }
-    .ask{
-        border-radius: 0;
-    }
+/* CSS for Phone */
+@media screen and (max-width: 768px) {
+  .heading {
+    font-size: 0.75rem;
+  }
+  .ask {
+    border-radius: 0;
+  }
 }

--- a/issue.css
+++ b/issue.css
@@ -1,158 +1,154 @@
-*{
-    margin: 0;
-    padding: 0;
-    }
-    
-    body{
-    background-color: #fdf0d5;
-    }
+* {
+  margin: 0;
+  padding: 0;
+}
 
-  html {
-    scroll-behavior: smooth;
-  }
-     
+body {
+  background-color: #fdf0d5;
+}
 
-    .progress-container {
-        width: 100%;
-        height: 4px; 
-        background: #EAE0D5; 
-        position: fixed; 
-        top: 0;
-        left: 0;
-        z-index: 1000; 
-        }
+html {
+  scroll-behavior: smooth;
+}
 
-    .progress-bar {
-        height: 100%;
-        width: 0%; 
-        background: #8B0000; 
-        }
-    .header {
-        min-height: 0vh;
-        width: 100%;
-        background-position: center;
-        background-size: cover;
-        position: relative;
-        padding-top: 20px;
-    }
+.progress-container {
+  width: 100%;
+  height: 4px;
+  background: #eae0d5;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+}
 
-    nav {
-        display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 0%;
-    margin-right: 6px;
-    background: #780000; /* Solid maroon background */
-    backdrop-filter: none; /* Optional: disable the blur if no longer needed */
-    -webkit-backdrop-filter: none; /* Optional: same for Safari */
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-    border-bottom: 1px solid rgba(179, 177, 177, 0.2);
-    position: fixed;
-    top: 0;
-    height: 7%;
-    width: 100%;
-    z-index: 999;
-    }
+.progress-bar {
+  height: 100%;
+  width: 0%;
+  background: #8b0000;
+}
+.header {
+  min-height: 0vh;
+  width: 100%;
+  background-position: center;
+  background-size: cover;
+  position: relative;
+  padding-top: 20px;
+}
 
-    .header1 {
-        background-color: #780000;
-    min-height:37vh;  
-    width: 100%;
-    background-position: center;
-    background-size: cover;
-    position: relative;
-    background-size:300% 300% ;
-    animation: color 12s ease-in-out infinite;
-    }
-    
-    
-    .text-box1 {
-color: #fdf0d5;
-font-family:"Crimson Text", serif;
-width: 90%;
-position: absolute;
-top: 50%;
-left: 50%;
-transform: translate(-50%, -50%);
-text-align: center;
+nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0%;
+  margin-right: 6px;
+  background: #780000; /* Solid maroon background */
+  backdrop-filter: none; /* Optional: disable the blur if no longer needed */
+  -webkit-backdrop-filter: none; /* Optional: same for Safari */
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+  position: fixed;
+  top: 0;
+  height: 7%;
+  width: 100%;
+  z-index: 999;
+}
+
+.header1 {
+  background-color: #780000;
+  min-height: 37vh;
+  width: 100%;
+  background-position: center;
+  background-size: cover;
+  position: relative;
+  background-size: 300% 300%;
+  animation: color 12s ease-in-out infinite;
+}
+
+.text-box1 {
+  color: #fdf0d5;
+  font-family: "Crimson Text", serif;
+  width: 90%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
 }
 
 .text-box1 h1 {
-margin-top: 15px;
-font-weight: 700;
-font-style: italic;
-font-size: 62px;
+  margin-top: 15px;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 62px;
 }
 .text-box1 p {
-margin: 10px 0 40px;
-font-size: 20px   
+  margin: 10px 0 40px;
+  font-size: 20px;
 }
 
-
-        .nav-links {
-    flex: 1;
-    text-align: right;
+.nav-links {
+  flex: 1;
+  text-align: right;
 }
 
 .nav-links ul li {
-    list-style: none;
-    display: inline-block;
-    padding: 8px 12px;
-    position: relative;
+  list-style: none;
+  display: inline-block;
+  padding: 8px 12px;
+  position: relative;
 }
 
-.nav-links ul li a{
-    color: #fdf0d5;
-    text-decoration: none;
-    font-family: serif;
-    font-size: 13px;
-    padding: 12px 16px;
-    display: block;
+.nav-links ul li a {
+  color: #fdf0d5;
+  text-decoration: none;
+  font-family: serif;
+  font-size: 13px;
+  padding: 12px 16px;
+  display: block;
 }
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+  transition: 0.3s ease;
 }
 .nav-links ul li::after {
-    content: '';
-    width: 0%;
-    height: 2px;
-    background: #fdf0d5;
-    display: block;
-    margin: auto;
-    transition: 0.5s;
+  content: "";
+  width: 0%;
+  height: 2px;
+  background: #fdf0d5;
+  display: block;
+  margin: auto;
+  transition: 0.5s;
 }
 
 .nav-links ul li:hover::after {
-    width: 100%;
+  width: 100%;
 }
 
 nav .fa {
-    display: none;
+  display: none;
 }
-        @media(max-width: 700px) {
-        .text-box h1 {
-        margin-top: 15px;
-        font-weight: 700;
-        font-style: italic;
-        font-size: 40px;
-        }
-        .nav-links ul li {
-            display: block;
-        }
-        .nav-links {
-            position: fixed;
-            background: #780000fc;
-            height: 100vh;
-            width: 200px;
-            top: 0;
-            right: -200px;
-            text-align: left;
-            z-index: 2;
-            transition: 1s;
-        }
-    
-        nav .fa-times {
+@media (max-width: 700px) {
+  .text-box h1 {
+    margin-top: 15px;
+    font-weight: 700;
+    font-style: italic;
+    font-size: 40px;
+  }
+  .nav-links ul li {
+    display: block;
+  }
+  .nav-links {
+    position: fixed;
+    background: #780000fc;
+    height: 100vh;
+    width: 200px;
+    top: 0;
+    right: -200px;
+    text-align: left;
+    z-index: 2;
+    transition: 1s;
+  }
+
+  nav .fa-times {
     display: block;
     color: #fdf0d5;
     margin: 10px;
@@ -161,60 +157,49 @@ nav .fa {
   }
   nav .fa-bars {
     display: block;
-    color: #780000fc; 
+    color: #780000fc;
     margin: 10px;
     font-size: 22px;
     cursor: pointer;
   }
-        .nav-links ul{
-            padding: 30px;
-        }
-        }
+  .nav-links ul {
+    padding: 30px;
+  }
+}
 
-        .footer {
-            background-color: #780000;
-            color: #fdf0d5;
-            margin-top: 55vh ;
-            width: 100%;
-            text-align: center;
-            padding: 30px 0;
-        
-        }
-        
-        .footer h4 {
-            color: #fdf0d5;
-            margin-bottom: 25px;
-            margin-top: 20px;
-            font-weight: 600;
-            font-family: 'Times New Roman', Times, serif;
-        
-        }
-        .footer p {
-            font-style: italic;
-            font-family: 'Times New Roman', Times, serif;
-            text-align: center;
-            font-size: 15px;
-        }
-        .icons {
-            color: #fdf0d5;
-            margin: 0 13px;
-            cursor: pointer;
-            padding: 18px 0;
-        }
-        
-        .fa-heart {
-            color: #fdf0d5;
-            font-size: 15px;
-        }
+.footer {
+  background-color: #780000;
+  color: #fdf0d5;
+  margin-top: 55vh;
+  width: 100%;
+  text-align: center;
+  padding: 30px 0;
+}
 
-/*        .issue01 {
+.footer h4 {
+  color: #fdf0d5;
+  margin-bottom: 25px;
+  margin-top: 20px;
+  font-weight: 600;
+  font-family: "Times New Roman", Times, serif;
+}
+.footer p {
+  font-style: italic;
+  font-family: "Times New Roman", Times, serif;
+  text-align: center;
+  font-size: 15px;
+}
+.icons {
+  color: #fdf0d5;
+  margin: 0 13px;
+  cursor: pointer;
+  padding: 18px 0;
+}
 
-            width: 80%;
-            margin: auto;
-            text-align: center;
-            padding-top: 20px;
-            
-       } */
+.fa-heart {
+  color: #fdf0d5;
+  font-size: 15px;
+}
 
 .issues {
   width: 90%;
@@ -225,15 +210,12 @@ nav .fa {
   padding-bottom: 100px;
 }
 
-
 .issue-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 50px;
   margin-top: 40px;
 }
-
-
 
 .issue-box {
   display: flex;
@@ -242,240 +224,233 @@ nav .fa {
   gap: 12px;
 }
 
+.issuecover {
+  background: linear-gradient(135deg, #fce8e4, #ffe9d1, #e1f2ec, #e3d6f7);
+  border-radius: 20px;
+  animation: shrinkPulse 4s ease-in-out infinite alternate,
+    color 5s ease-in-out infinite;
+  background-size: 400% 400%;
+  width: 48%; /* Shrink the cover width */
+  margin: 0 auto 30px auto; /* Center and add bottom margin */
+  position: relative;
+  overflow: hidden;
+  padding: 25px 0 45px 0; /* Top and bottom padding for spacing */
+  box-shadow: 0 0 20px #000000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+@keyframes color {
+  0% {
+    background-position: 0 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
 
+@keyframes shrinkPulse {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(0.85);
+  }
+}
+.issuecover img {
+  width: 85%;
+  display: block;
+  margin-top: 10px;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 10px;
+}
 
-
-       .issuecover {
-        background: linear-gradient(135deg, #fce8e4, #ffe9d1, #e1f2ec, #e3d6f7);
-        border-radius: 20px;
-        animation: shrinkPulse 4s ease-in-out infinite alternate, color 5s ease-in-out infinite;
-        background-size: 400% 400%;
-        width: 48%;           /* Shrink the cover width */
-        margin: 0 auto 30px auto; /* Center and add bottom margin */
-        position: relative;
-        overflow: hidden;
-        padding: 25px 0 45px 0; /* Top and bottom padding for spacing */
-        box-shadow: 0 0 20px #000000;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        }
-        @keyframes color {
-                       0% {
-                           background-position: 0 50%;
-                           }
-                         50% {
-                           background-position: 100% 50%;
-                         }
-                        100% {
-                           background-position: 0 50%;
-                         }
-                        }
-    
-        @keyframes shrinkPulse {
-        0% {
-            transform: scale(1);
-           }
-      100% {
-            transform: scale(0.85);
-           }
-}        
-            .issuecover img {
-            width: 85%;
-            display: block;
-            margin-top: 10px;
-            margin-left: auto;
-            margin-right: auto;
-            border-radius: 10px;
-            }
-
-
-            .layer {
-            background: transparent;
-            text-align: center;
-            height: 100%;
-            width: 100%;
-            position: absolute;
-            top: 0;
-            left: 0px;
-            transition: 0.5s;
-            padding-top: 20px;
-            }
-            
+.layer {
+  background: transparent;
+  text-align: center;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0px;
+  transition: 0.5s;
+  padding-top: 20px;
+}
 
 .issuecover h3 {
-    text-align: center;
-    color: #6b4b3e;
-    font-weight: 700;
-    font-style: italic;
-    font-size: 35px;
-    padding-top: 20px;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-} 
+  text-align: center;
+  color: #6b4b3e;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 35px;
+  padding-top: 20px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
 
+#pdf {
+  display: inline-block;
+  text-decoration: none;
+  color: #365144;
+  border-radius: 20px;
+  padding: 12px 34px;
+  font-size: 13px;
+  background: #d5f5e3;
+  position: relative;
+  cursor: pointer;
+  font-weight: 600;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  box-shadow: 0 0 10px #00ffff44;
+}
 
-                #pdf {
-                    display: inline-block;
-                    text-decoration: none;
-                    color:#365144;
-                    border-radius: 20px;
-                    padding: 12px 34px;
-                    font-size: 13px;
-                    background: #d5f5e3;
-                    position: relative;
-                    cursor: pointer;
-                    font-weight: 600;
-                     transition: box-shadow 0.3s ease, transform 0.3s ease;
-                     box-shadow: 0 0 10px #00ffff44;
-                }
-                
-                #pdf:hover {
-                   box-shadow: 0 0 20px #00ffffaa, 0 0 40px #00ffffaa;
-                     box-shadow: 0 0 20px #f69cc4aa, 0 0 40px #f69cc4aa;
-                   background: transparent;
-                   transform: scale(1.05);
-                   outline: none;
-                }
-                
-                
-                #flipbook {
-                    display: inline-block;
-                    text-decoration: none;
-                    color: #365144;
-                    border-radius: 20px;
-                    padding: 12px 34px;
-                    font-size: 13px;
-                    margin-left: 10px;
-                    background:#7ccc9b;
-                    background:#d5f5e3;
-                    position: relative;
-                    cursor: pointer;
-                    font-weight: 600;
-                    transition: box-shadow 0.3s ease, transform 0.3s ease;
-                     box-shadow: 0 0 10px #00ffff44;
-                }
-                
-                #flipbook:hover {
-                   box-shadow: 0 0 20px #f69cc4aa, 0 0 40px #f69cc4aa;
-                   background: transparent;
-                   transform: scale(1.05);
-                   outline: none;
-                }
-                
-                @media(max-width: 700px) {
-                    .issues {
-                        width: 100%;
-                    } 
-                    .issuecover img {
-                        width: 90%;
-                    }
-                }
+#pdf:hover {
+  box-shadow: 0 0 20px #00ffffaa, 0 0 40px #00ffffaa;
+  box-shadow: 0 0 20px #f69cc4aa, 0 0 40px #f69cc4aa;
+  background: transparent;
+  transform: scale(1.05);
+  outline: none;
+}
 
-        .h1k {
-            text-align: center;
-            padding-left: 40px;
-            font-style: italic;
-            color: #780000;
-            font-size: 35px;
-        }
+#flipbook {
+  display: inline-block;
+  text-decoration: none;
+  color: #365144;
+  border-radius: 20px;
+  padding: 12px 34px;
+  font-size: 13px;
+  margin-left: 10px;
+  background: #7ccc9b;
+  background: #d5f5e3;
+  position: relative;
+  cursor: pointer;
+  font-weight: 600;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  box-shadow: 0 0 10px #00ffff44;
+}
 
-        .h2k {
-            margin-top: 30px;
-            text-align: center;
-            padding-left: 40px;
-            font-style: italic;
-            color: #780000;
-            font-size: 20px;
-        }
-    
- 
-        .intro {
-            color: #111717;
-            font-size: 19px;
-            font-weight: 300;
-            line-height: 22px;
-            padding: 10px;
-            font-style: italic;
-            font-family: 'Times New Roman', Times, serif;
-        }
-                
-        .social {
-            color: #780000;
-            font-size: 19px;
-            font-weight: 300;
-            line-height: 22px;
-            padding: 10px;
-            font-style: italic;
-            font-family: 'Times New Roman', Times, serif;
-        }
-        
-        .icons {
-            color: #fdf0d5;
-            margin: 0 13px;
-            cursor: pointer;
-            padding: 18px 0;
-        }
-        
-        .icons a {
-            color: #fdf0d5;
-            font-size: 25px;
-        } 
-        .fa-heart {
-            color: #fdf0d5;
-            font-size: 15px;
-        }
+#flipbook:hover {
+  box-shadow: 0 0 20px #f69cc4aa, 0 0 40px #f69cc4aa;
+  background: transparent;
+  transform: scale(1.05);
+  outline: none;
+}
+
+@media (max-width: 700px) {
+  .issues {
+    width: 100%;
+  }
+  .issuecover img {
+    width: 90%;
+  }
+}
+
+.h1k {
+  text-align: center;
+  padding-left: 40px;
+  font-style: italic;
+  color: #780000;
+  font-size: 35px;
+}
+
+.h2k {
+  margin-top: 30px;
+  text-align: center;
+  padding-left: 40px;
+  font-style: italic;
+  color: #780000;
+  font-size: 20px;
+}
+
+.intro {
+  color: #111717;
+  font-size: 19px;
+  font-weight: 300;
+  line-height: 22px;
+  padding: 10px;
+  font-style: italic;
+  font-family: "Times New Roman", Times, serif;
+}
+
+.social {
+  color: #780000;
+  font-size: 19px;
+  font-weight: 300;
+  line-height: 22px;
+  padding: 10px;
+  font-style: italic;
+  font-family: "Times New Roman", Times, serif;
+}
+
+.icons {
+  color: #fdf0d5;
+  margin: 0 13px;
+  cursor: pointer;
+  padding: 18px 0;
+}
+
+.icons a {
+  color: #fdf0d5;
+  font-size: 25px;
+}
+.fa-heart {
+  color: #fdf0d5;
+  font-size: 15px;
+}
 
 /** FOOTER **/
 
 .site-footer {
   background: #7a0000;
   color: #f9f9e6;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
   padding: 50px 20px 15px;
 }
 
 /* Back-to-top button */
 .back-to-top {
-    position: fixed;
-    height: 45px;
-    width: 45px;
-    bottom: 16px;
-    right: 30px;
-    font-size: 26px;
-    background-color: #780000;
-    color: #fdf0d5;
-    border-radius: 50%;;
-    text-decoration: none;
-    display: flex;
-    opacity: 0;
-    pointer-events: none;
-    justify-content: center;
-    align-items: center;
-    box-shadow: 0px 0px 10px #fdf0d5;
-    transition: all .4s;
+  position: fixed;
+  height: 45px;
+  width: 45px;
+  bottom: 16px;
+  right: 30px;
+  font-size: 26px;
+  background-color: #780000;
+  color: #fdf0d5;
+  border-radius: 50%;
+  text-decoration: none;
+  display: flex;
+  opacity: 0;
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 0px 10px #fdf0d5;
+  transition: all 0.4s;
 }
 
 .back-to-top.active {
-    bottom: 30px;
-    opacity: 1;
-    pointer-events: auto;
+  bottom: 30px;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .back-to-top:focus {
-    outline:none;
+  outline: none;
 }
 
 .back-to-top:hover {
-    background-color: #fdf0d5;
-    color: #780000;
-    box-shadow: 0px 0px 10px #780000;
-    font-size: 28px;
+  background-color: #fdf0d5;
+  color: #780000;
+  box-shadow: 0px 0px 10px #780000;
+  font-size: 28px;
 }
 
 /* Top section */
 .footer-top {
   display: grid;
-  justify-content:center ;
+  justify-content: center;
   grid-template-columns: 28% 10% 13% 30%;
   gap: 40px;
   margin-bottom: 100px;
@@ -544,7 +519,7 @@ nav .fa {
   font-size: 18px;
   color: #fff8e7;
   margin-bottom: 10px;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
 }
 
 .subscription-box form {
@@ -558,7 +533,7 @@ nav .fa {
   border-radius: 15px;
   margin-bottom: 10px;
 }
-  
+
 .subscription-box button {
   background: #ffcc66;
   color: #7a0000;
@@ -575,7 +550,7 @@ nav .fa {
 .subscription-box button:hover {
   background: #e6b85c;
 }
-button:active{
+button:active {
   scale: 0.95;
 }
 /* Bottom bar */
@@ -610,4 +585,3 @@ button:active{
     width: 100%;
   }
 }
-

--- a/masthead.css
+++ b/masthead.css
@@ -1,5 +1,3 @@
-
-
 * {
   margin: 0;
   padding: 0;
@@ -17,18 +15,18 @@ html {
 
 .progress-container {
   width: 100%;
-  height: 4px; 
-  background: #EAE0D5; 
-  position: fixed; 
+  height: 4px;
+  background: #eae0d5;
+  position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000; 
+  z-index: 1000;
 }
 
 .progress-bar {
   height: 100%;
-  width: 0%; 
-  background: #8B0000; 
+  width: 0%;
+  background: #8b0000;
 }
 
 .header {
@@ -57,7 +55,7 @@ nav {
   top: 0;
   height: 9%;
   width: 100%;
-  z-index: 999; 
+  z-index: 999;
 }
 
 .header1 {
@@ -106,12 +104,12 @@ nav {
   }
 }
 
-nav{
-    display: flex;
-    background-color: #780000;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0px 5%;
+nav {
+  display: flex;
+  background-color: #780000;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0px 5%;
 }
 .nav-links {
   flex: 1;
@@ -143,7 +141,6 @@ nav{
   transition: 0.5s;
 }
 .nav-links ul li a:hover {
-  text-decoration: underline;
   transition: 0.3s ease;
 }
 .nav-links ul li:hover::after {
@@ -206,29 +203,26 @@ nav .fa {
     font-size: 25px;
   }
 
+  .founder-card,
+  .founder-content {
+    flex-direction: column;
+    padding: 1.2rem;
+  }
 
-    .founder-card,
-    .founder-content {
-        flex-direction: column;
-        padding: 1.2rem;
-    }
+  .founder-name {
+    font-size: 1.5rem;
+    text-align: center;
+  }
 
-    .founder-name {
-        font-size: 1.5rem;
-        text-align: center;
-    }
+  .founder-card .role {
+    text-align: center;
+  }
 
-    .founder-card .role {
-        text-align: center;
-    }
-
-    .founder-card .intro,
-    .founder-card .social-link {
-        text-align: justify;
-    }
-
+  .founder-card .intro,
+  .founder-card .social-link {
+    text-align: justify;
+  }
 }
-
 
 .people {
   width: 80%;
@@ -245,74 +239,69 @@ nav .fa {
 }
 
 .team-container {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    margin: 2rem auto;
-    max-width: 1200px;
-    padding: 1rem;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 2rem auto;
+  max-width: 1200px;
+  padding: 1rem;
+  align-items: center;
 }
-
 
 .founder-card {
-    display: flex;
-    flex-direction: column;
-    background: linear-gradient(to bottom, #fffefe, #fbfafa, #d3cdcd, #fffefe);
-    border-radius: 15px;
-    padding: 2rem;
-    box-shadow: 0 4px 12px rgba(106, 13, 173, 0.1);
-    transition: transform 0.6s ease-in-out 0.3s,
-                box-shadow 0.6s ease-in-out 0.3s;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(to bottom, #fffefe, #fbfafa, #d3cdcd, #fffefe);
+  border-radius: 15px;
+  padding: 2rem;
+  box-shadow: 0 4px 12px rgba(106, 13, 173, 0.1);
+  transition: transform 0.6s ease-in-out 0.3s,
+    box-shadow 0.6s ease-in-out 0.3s;
 }
 
-
-.founder-card:hover{
-
-   transform: translateY(-5px);
-   box-shadow: 0 6px 12px rgba(0,0,0,0.6);
+.founder-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.6);
 }
 
 .founder-content {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    gap: 1.5rem;
-    width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 1.5rem;
+  width: 100%;
 }
 
 .founder-text {
-    flex: 1;
+  flex: 1;
 }
 
 .founder-name {
-    font-size: 2rem;
-    color: #6a0dad;
-    margin-bottom: 0.3rem;
+  font-size: 2rem;
+  color: #6a0dad;
+  margin-bottom: 0.3rem;
 }
 
 .founder-card .role {
-    font-weight: bold;
-    color: #444;
-    margin-bottom: 1rem;
+  font-weight: bold;
+  color: #444;
+  margin-bottom: 1rem;
 }
 
 .founder-card .intro {
-    color: #333;
-    line-height: 1.6;
-    margin-bottom: 0.8rem;
+  color: #333;
+  line-height: 1.6;
+  margin-bottom: 0.8rem;
 }
 
 .founder-card .social-link a {
-    color: #f2f2f3;
-    text-decoration: none;
-    font-weight: bold;
+  color: #f2f2f3;
+  text-decoration: none;
+  font-weight: bold;
 }
 .founder-card .social-link a:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
-
-
 
 .team-grid {
   display: grid;
@@ -323,21 +312,20 @@ nav .fa {
 }
 
 .team-card {
-  background: linear-gradient(to right, #cdb2ad,#fdf0d5, #bcaf87);
+  background: linear-gradient(to right, #cdb2ad, #fdf0d5, #bcaf87);
   border: 2px solid #780000;
   border-radius: 15px;
   padding: 1.5rem;
   color: #780000;
   /* font-family: 'Crimson Text', serif; */
-  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
-
 }
 
 .team-card:hover {
-  background: linear-gradient(to bottom, #bcaf87,#fdf0d5, #cdb2ad);
+  background: linear-gradient(to bottom, #bcaf87, #fdf0d5, #cdb2ad);
   transform: translateY(-5px);
-  box-shadow: 0 6px 12px rgba(0,0,0,0.6);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.6);
 }
 
 .team-card h3 {
@@ -371,30 +359,6 @@ nav .fa {
   background-color: #a30000;
 }
 
-
-
-/* .mh10{
-    width: 50%;
-    margin: auto;
-    text-align: center;
-    padding-top: 10px;
-    }       
-.mh10 img {
-    padding-top: 0px;
-    width: 30%;
-    border-radius: 10px;
-    
-}
-@media(max-width: 700px) {
-   
-    .mh10 img {
-        width: 60%;
-        border-radius: 10px;
-    }
-    .mh10 {
-        width: 100%;
-    }  */
-/* } */
 .intro {
   color: #111717;
   font-size: 19px;
@@ -402,7 +366,6 @@ nav .fa {
   line-height: 22px;
   padding: 10px;
   font-style: italic;
-  /* font-family: "Times New Roman", Times, serif; */
 }
 
 .social {
@@ -441,52 +404,52 @@ nav .fa {
 .site-footer {
   background: #7a0000;
   color: #f9f9e6;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
   padding: 50px 20px 15px;
 }
 
 /* Back-to-top button */
 .back-to-top {
-    position: fixed;
-    height: 45px;
-    width: 45px;
-    bottom: 16px;
-    right: 30px;
-    font-size: 26px;
-    background-color: #780000;
-    color: #fdf0d5;
-    border-radius: 50%;;
-    text-decoration: none;
-    display: flex;
-    opacity: 0;
-    pointer-events: none;
-    justify-content: center;
-    align-items: center;
-    box-shadow: 0px 0px 10px #fdf0d5;
-    transition: all .4s;
+  position: fixed;
+  height: 45px;
+  width: 45px;
+  bottom: 16px;
+  right: 30px;
+  font-size: 26px;
+  background-color: #780000;
+  color: #fdf0d5;
+  border-radius: 50%;
+  text-decoration: none;
+  display: flex;
+  opacity: 0;
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 0px 10px #fdf0d5;
+  transition: all 0.4s;
 }
 
 .back-to-top.active {
-    bottom: 30px;
-    opacity: 1;
-    pointer-events: auto;
+  bottom: 30px;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .back-to-top:focus {
-    outline:none;
+  outline: none;
 }
 
 .back-to-top:hover {
-    background-color: #fdf0d5;
-    color: #780000;
-    box-shadow: 0px 0px 10px #780000;
-    font-size: 28px;
+  background-color: #fdf0d5;
+  color: #780000;
+  box-shadow: 0px 0px 10px #780000;
+  font-size: 28px;
 }
 
 /* Top section */
 .footer-top {
   display: grid;
-  justify-content:center ;
+  justify-content: center;
   grid-template-columns: 28% 10% 13% 30%;
   gap: 40px;
   margin-bottom: 100px;
@@ -555,7 +518,7 @@ nav .fa {
   font-size: 18px;
   color: #fff8e7;
   margin-bottom: 10px;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
 }
 
 .subscription-box form {
@@ -569,7 +532,7 @@ nav .fa {
   border-radius: 15px;
   margin-bottom: 10px;
 }
-  
+
 .subscription-box button {
   background: #ffcc66;
   color: #7a0000;
@@ -586,7 +549,7 @@ nav .fa {
 .subscription-box button:hover {
   background: #e6b85c;
 }
-button:active{
+button:active {
   scale: 0.95;
 }
 /* Bottom bar */
@@ -637,4 +600,3 @@ button:active{
     margin: 0 0 1.5rem 0;
   }
 }
-

--- a/style.css
+++ b/style.css
@@ -1,67 +1,63 @@
-*{
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 html {
-    scroll-behavior: smooth;
+  scroll-behavior: smooth;
 }
 
-body{
-    background-color: #fdf0d5;
-    line-height: 1.6;
+body {
+  background-color: #fdf0d5;
+  line-height: 1.6;
 }
 
 .progress-container {
   width: 100%;
-  height: 4px; 
-  background: #EAE0D5; 
-  position: fixed; 
+  height: 4px;
+  background: #eae0d5;
+  position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000; 
+  z-index: 1000;
 }
 
 .progress-bar {
   height: 100%;
-  width: 0%; 
-  background: #8B0000; 
+  width: 0%;
+  background: #8b0000;
 }
 
 .header {
-    min-height: 40vh;
-    min-height: 40vh;
-    min-height: 60vh;
-    width: 100%;
-    background-color: #780000;
-    background-position: center;
-    background-size: cover;
-    position: relative;
-    padding-top: 80px;
-    
+  min-height: 40vh;
+  min-height: 40vh;
+  min-height: 60vh;
+  width: 100%;
+  background-color: #780000;
+  background-position: center;
+  background-size: cover;
+  position: relative;
+  padding-top: 80px;
 }
 
 nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 5%;
-    margin-right: 6px;
-    background: #780000; /* Solid maroon background */
-    backdrop-filter: none; /* Optional: disable the blur if no longer needed */
-    -webkit-backdrop-filter: none; /* Optional: same for Safari */
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-    border-bottom: 1px solid rgba(179, 177, 177, 0.2);
-    position: fixed;
-    top: 0;
-    height: 9%;
-    width: 100%;
-    z-index: 999;
-    
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 5%;
+  margin-right: 6px;
+  background: #780000; /* Solid maroon background */
+  backdrop-filter: none; /* Optional: disable the blur if no longer needed */
+  -webkit-backdrop-filter: none; /* Optional: same for Safari */
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+  position: fixed;
+  top: 0;
+  height: 9%;
+  width: 100%;
+  z-index: 999;
 }
-
-
 
 .text-box {
   color: #fdf0d5;
@@ -71,71 +67,66 @@ nav {
   margin: 0 auto;
 }
 
-
 .text-box h1 {
-    margin-top: 100px;
-    font-weight: 700;
-    font-style: italic;
-    font-size: 62px;
+  margin-top: 100px;
+  font-weight: 700;
+  font-style: italic;
+  font-size: 62px;
 }
 
 .text-box p {
-    margin: 10px 0 40px;
-    font-size: 14px
-    
+  margin: 10px 0 40px;
+  font-size: 14px;
 }
 .nav-links {
-    flex: 1;
-    text-align: right;
-    position: relative;
-    z-index: 10;
+  flex: 1;
+  text-align: right;
+  position: relative;
+  z-index: 10;
 }
 
 .nav-links ul li {
-    list-style: none;
-    display: inline-block;
-    padding: 8px 12px;
-    position: relative;
-
+  list-style: none;
+  display: inline-block;
+  padding: 8px 12px;
+  position: relative;
 }
 
-.nav-links ul li a{
-    color: #fdf0d5;
-    text-decoration: none;
-    font-family: serif;
-    font-size: 13px;
-    padding: 12px 16px;
-    display: block;
-
+.nav-links ul li a {
+  color: #fdf0d5;
+  text-decoration: none;
+  font-family: serif;
+  font-size: 13px;
+  padding: 12px 16px;
+  display: block;
 }
 
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+  transition: 0.3s ease;
 }
 
 .nav-links ul li::after {
-    content: '';
-    width: 0%;
-    height: 2px;
-    background: #fdf0d5;
-    display: block;
-    margin: auto;
-    transition: 0.5s;
+  content: "";
+  width: 0%;
+  height: 2px;
+  background: #fdf0d5;
+  display: block;
+  margin: auto;
+  transition: 0.5s;
 }
 
 .nav-links ul li:hover::after {
-    width: 100%;
+  width: 100%;
 }
 
 nav .fa {
-    display: none;
+  display: none;
 }
 .container {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px; 
-  justify-content: center; 
+  gap: 16px;
+  justify-content: center;
   align-items: flex-start;
 }
 .card-title {
@@ -183,25 +174,25 @@ nav .fa {
   position: relative;
   width: 300px;
   height: 400px;
-  background-color: rgba(234, 171, 214,0.4);
+  background-color: rgba(234, 171, 214, 0.4);
   border-radius: 10px;
   padding: 2em 1.2em;
   margin: 12px;
   text-decoration: none;
   z-index: 0;
   overflow: hidden;
-  background: linear-gradient(to bottom,#cdb2ad,#fdf0d5, #bcaf87);
+  background: linear-gradient(to bottom, #cdb2ad, #fdf0d5, #bcaf87);
   font-family: Arial, Helvetica, sans-serif;
   box-shadow: 10px 10px 20px #c6bcc5;
 }
 
 .card:before {
-  content: '';
+  content: "";
   position: absolute;
   z-index: -1;
   top: -16px;
   right: -16px;
-  background: linear-gradient(135deg, #8B0000, #5a0000); 
+  background: linear-gradient(135deg, #8b0000, #5a0000);
   height: 40px;
   width: 40px;
   border-radius: 32px;
@@ -224,168 +215,164 @@ nav .fa {
   color: #ffffff;
 }
 
-
 /* Responsive Design Enhancements */
 @media (max-width: 700px) {
-    .text-box h1 {
-        margin-top: 15px;
-        font-weight: 700;
-        font-style: italic;
-        font-size: clamp(32px, 6vw, 40px);
-    }
+  .text-box h1 {
+    margin-top: 15px;
+    font-weight: 700;
+    font-style: italic;
+    font-size: clamp(32px, 6vw, 40px);
+  }
 
-    nav{
-      height: 7%;
-    }
+  nav {
+    height: 7%;
+  }
 
-    .text-box p {
-        font-size: clamp(12px, 2vw, 14px);
-    }
+  .text-box p {
+    font-size: clamp(12px, 2vw, 14px);
+  }
 
-    .nav-links ul {
-        display: grid;
-        grid-template-columns: 1fr;
-        gap: 16px;
-        padding: 40px 20px;
-    }
+  .nav-links ul {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding: 40px 20px;
+  }
 
-    .nav-links ul li {
-        display: block;
-        opacity: 0;
-        transform: translateX(30px);
-        animation: slideIn 0.4s forwards;
-    }
+  .nav-links ul li {
+    display: block;
+    opacity: 0;
+    transform: translateX(30px);
+    animation: slideIn 0.4s forwards;
+  }
 
-    @keyframes slideIn {
-        to {
-            opacity: 1;
-            transform: translateX(0);
-        }
+  @keyframes slideIn {
+    to {
+      opacity: 1;
+      transform: translateX(0);
     }
+  }
 
-    .nav-links {
-        position: fixed;
-        background: #780000fc;
-        height: 100vh;
-        width: 200px;
-        top: 0;
-        right: -100%;
-        text-align: left;
-        z-index: 2;
-        transition: right 0.4s ease-in-out;
-    }
+  .nav-links {
+    position: fixed;
+    background: #780000fc;
+    height: 100vh;
+    width: 200px;
+    top: 0;
+    right: -100%;
+    text-align: left;
+    z-index: 2;
+    transition: right 0.4s ease-in-out;
+  }
 
-    .nav-links.nav-active {
-        right: 0;
-    }
+  .nav-links.nav-active {
+    right: 0;
+  }
 
-    nav .fa {
-        display: block;
-        color: #fdf0d5;
-        margin: 10px;
-        font-size: 22px;
-        cursor: pointer;
-        z-index: 10;
-    }
+  nav .fa {
+    display: block;
+    color: #fdf0d5;
+    margin: 10px;
+    font-size: 22px;
+    cursor: pointer;
+    z-index: 10;
+  }
 }
 
 .Welcome {
-    width: 80%;
-    margin: auto;
-    text-align: center;
-    padding-top: 80px;
+  width: 80%;
+  margin: auto;
+  text-align: center;
+  padding-top: 80px;
 }
 #namaste {
-    font-size: 36px;
-    font-weight: 600;
-    font-family: serif;
-    font-style: italic;
-    color: #652e4d;
-    font-size: 2.5rem;
-    text-shadow: 0 0 5px #cea8bc, 0 0 10px #ffa7f2;
+  font-size: 36px;
+  font-weight: 600;
+  font-family: serif;
+  font-style: italic;
+  color: #652e4d;
+  font-size: 2.5rem;
+  text-shadow: 0 0 5px #cea8bc, 0 0 10px #ffa7f2;
 }
 
 #intro {
-    font-size: 19px;
-    font-weight: 300;
-    line-height: 22px;
-    padding: 2rem;
-    font-style: italic;
-    font-family: 'Times New Roman', Times, serif;
-    /* max-width: 75ch; */
+  font-size: 19px;
+  font-weight: 300;
+  line-height: 22px;
+  padding: 2rem;
+  font-style: italic;
+  font-family: "Times New Roman", Times, serif;
+  /* max-width: 75ch; */
 }
 
 #issue1-btn {
-    display: inline-block;
-    text-decoration: none;
-    color: white;
-    border:none;
-    border-radius: 95px 8px;
-    padding: 12px 34px;
-    font-size: 13px;
-    margin-top: 15px;
-    background: linear-gradient(45deg, #37163a, pink);
-    position: relative;
-    cursor: pointer;
-    font-weight: 600;
+  display: inline-block;
+  text-decoration: none;
+  color: white;
+  border: none;
+  border-radius: 95px 8px;
+  padding: 12px 34px;
+  font-size: 13px;
+  margin-top: 15px;
+  background: linear-gradient(45deg, #37163a, pink);
+  position: relative;
+  cursor: pointer;
+  font-weight: 600;
 }
 
 #issue1-btn:hover {
-    border: 1px solid #780000;
-     background: linear-gradient(45deg, pink,  #37163a);
-    transition: 1s;
+  border: 1px solid #780000;
+  background: linear-gradient(45deg, pink, #37163a);
+  transition: 1s;
 }
 
 #cta1-btn {
-    display: inline-block;
-    text-decoration: none;
-    color:#f9f9e6;
-    border: none;
-    border-radius: 8px 95px;
-    margin-top: 10px;
-    padding: 12px 46px;
-    font-size: 13px;
-     background: linear-gradient(45deg, pink,  #37163a);
-    position: relative;
-    cursor: pointer;
-    font-weight: 600;
+  display: inline-block;
+  text-decoration: none;
+  color: #f9f9e6;
+  border: none;
+  border-radius: 8px 95px;
+  margin-top: 10px;
+  padding: 12px 46px;
+  font-size: 13px;
+  background: linear-gradient(45deg, pink, #37163a);
+  position: relative;
+  cursor: pointer;
+  font-weight: 600;
 }
 
 #cta1-btn:hover {
-    border: 1px solid #780000;
-     background: linear-gradient(45deg, #37163a, pink);
-    transition: 1s;
+  border: 1px solid #780000;
+  background: linear-gradient(45deg, #37163a, pink);
+  transition: 1s;
 }
 
 /* Main container for the section */
 .listings {
-    width: 80%;
-    margin: 4rem auto; /* Adds space above and below the section */
-    text-align: center;
+  width: 80%;
+  margin: 4rem auto; /* Adds space above and below the section */
+  text-align: center;
 }
-
 
 .listings h3 {
-    font-family: serif;
-    font-style: italic;
-    font-size: 24px;
-    color: #780000;
-    margin-bottom: 2rem; 
+  font-family: serif;
+  font-style: italic;
+  font-size: 24px;
+  color: #780000;
+  margin-bottom: 2rem;
 }
-
 
 .listing-images {
-    display: flex;
-    justify-content: center; 
-    align-items: center;  
-    gap: 3rem;             
-    flex-wrap: wrap;       
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 3rem;
+  flex-wrap: wrap;
 }
 
-
 .listing-images img {
-    max-width: 250px; 
-    height: auto;     
+  max-width: 250px;
+  height: auto;
 }
 
 /** FOOTER **/
@@ -393,52 +380,52 @@ nav .fa {
 .site-footer {
   background: #7a0000;
   color: #f9f9e6;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
   padding: 50px 20px 15px;
 }
 
 /* Back-to-top button */
 .back-to-top {
-    position: fixed;
-    height: 45px;
-    width: 45px;
-    bottom: 16px;
-    right: 30px;
-    font-size: 26px;
-    background-color: #780000;
-    color: #fdf0d5;
-    border-radius: 50%;;
-    text-decoration: none;
-    display: flex;
-    opacity: 0;
-    pointer-events: none;
-    justify-content: center;
-    align-items: center;
-    box-shadow: 0px 0px 10px #fdf0d5;
-    transition: all .4s;
+  position: fixed;
+  height: 45px;
+  width: 45px;
+  bottom: 16px;
+  right: 30px;
+  font-size: 26px;
+  background-color: #780000;
+  color: #fdf0d5;
+  border-radius: 50%;
+  text-decoration: none;
+  display: flex;
+  opacity: 0;
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 0px 10px #fdf0d5;
+  transition: all 0.4s;
 }
 
 .back-to-top.active {
-    bottom: 30px;
-    opacity: 1;
-    pointer-events: auto;
+  bottom: 30px;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .back-to-top:focus {
-    outline:none;
+  outline: none;
 }
 
 .back-to-top:hover {
-    background-color: #fdf0d5;
-    color: #780000;
-    box-shadow: 0px 0px 10px #780000;
-    font-size: 28px;
+  background-color: #fdf0d5;
+  color: #780000;
+  box-shadow: 0px 0px 10px #780000;
+  font-size: 28px;
 }
 
 /* Top section */
 .footer-top {
   display: grid;
-  justify-content:center ;
+  justify-content: center;
   grid-template-columns: 28% 10% 13% 30%;
   gap: 40px;
   margin-bottom: 100px;
@@ -507,7 +494,7 @@ nav .fa {
   font-size: 18px;
   color: #fff8e7;
   margin-bottom: 10px;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
 }
 
 .subscription-box form {
@@ -521,7 +508,7 @@ nav .fa {
   border-radius: 15px;
   margin-bottom: 10px;
 }
-  
+
 .subscription-box button {
   background: #ffcc66;
   color: #7a0000;
@@ -539,7 +526,7 @@ nav .fa {
   background: #e6b85c;
 }
 
-button:active{
+button:active {
   scale: 0.95;
 }
 /* Bottom bar */
@@ -575,11 +562,10 @@ button:active{
   }
 }
 
-
 /* Your Quote Widget */
 #quote-widget {
   margin-top: 15px;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
   color: #fdf0d5;
   font-style: italic;
   text-align: center;
@@ -602,74 +588,72 @@ button:active{
 }
 /*Loading page*/
 #loading-screen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100vh;
-    background: #fdf0d5;
-    color: #780000;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-    transition: opacity 0.5s ease, visibility 0.5s ease;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background: #fdf0d5;
+  color: #780000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  transition: opacity 0.5s ease, visibility 0.5s ease;
 }
 
 #loading-screen.hidden {
-    opacity: 0;
-    visibility: hidden;
+  opacity: 0;
+  visibility: hidden;
 }
 
 .loader {
-    text-align: center;
+  text-align: center;
 }
 
 .loader i {
-    font-size: 4.5rem;
-    animation: spin 2s linear infinite;
+  font-size: 4.5rem;
+  animation: spin 2s linear infinite;
 }
 
 .loader h2 {
-    margin-top: 1.5rem;
-    font-size: 2.1rem;
+  margin-top: 1.5rem;
+  font-size: 2.1rem;
 }
 
 .dots::after {
-    content: "";
-    display: inline-block;
-    animation: dots 1.5s steps(5, end) infinite;
+  content: "";
+  display: inline-block;
+  animation: dots 1.5s steps(5, end) infinite;
 }
 
 @keyframes dots {
-    0% {
-        content: "";
-    }
-    20% {
-        content: ".";
-    }
-    40% {
-        content: "..";
-    }
-    60% {
-        content: "...";
+  0% {
+    content: "";
   }
-    80%{
-        content: "....";
-    }
-    100% {
-        content: "";
-    }
+  20% {
+    content: ".";
+  }
+  40% {
+    content: "..";
+  }
+  60% {
+    content: "...";
+  }
+  80% {
+    content: "....";
+  }
+  100% {
+    content: "";
+  }
 }
 
 /* Spin Animation */
 @keyframes spin {
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
-    }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
-
-

--- a/submission.css
+++ b/submission.css
@@ -13,18 +13,18 @@ html {
 
 .progress-container {
   width: 100%;
-  height: 4px; 
-  background: #EAE0D5; 
-  position: fixed; 
+  height: 4px;
+  background: #eae0d5;
+  position: fixed;
   top: 0;
   left: 0;
-  z-index: 1000; 
+  z-index: 1000;
 }
 
 .progress-bar {
   height: 100%;
-  width: 0%; 
-  background: #8B0000; 
+  width: 0%;
+  background: #8b0000;
 }
 
 .header {
@@ -37,21 +37,21 @@ html {
 }
 
 nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 0%;
-    margin-right: 6px;
-    background: #780000; /* Solid maroon background */
-    backdrop-filter: none; /* Optional: disable the blur if no longer needed */
-    -webkit-backdrop-filter: none; /* Optional: same for Safari */
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-    border-bottom: 1px solid rgba(179, 177, 177, 0.2);
-    position: fixed;
-    top: 0;
-    height: 9%;
-    width: 100%;
-    z-index: 999;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0%;
+  margin-right: 6px;
+  background: #780000; /* Solid maroon background */
+  backdrop-filter: none; /* Optional: disable the blur if no longer needed */
+  -webkit-backdrop-filter: none; /* Optional: same for Safari */
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid rgba(179, 177, 177, 0.2);
+  position: fixed;
+  top: 0;
+  height: 9%;
+  width: 100%;
+  z-index: 999;
 }
 
 .header1 {
@@ -73,7 +73,6 @@ nav {
   left: 50%;
   transform: translate(-50%, -50%);
   text-align: center;
-
 }
 
 .text-box1 h1 {
@@ -108,9 +107,8 @@ nav {
   padding: 12px 16px;
   display: block;
 }
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+  transition: 0.3s ease;
 }
 .nav-links ul li::after {
   content: "";
@@ -175,52 +173,52 @@ nav .fa {
 .site-footer {
   background: #7a0000;
   color: #f9f9e6;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
   padding: 50px 20px 15px;
 }
 
 /* Back-to-top button */
 .back-to-top {
-    position: fixed;
-    height: 45px;
-    width: 45px;
-    bottom: 16px;
-    right: 30px;
-    font-size: 26px;
-    background-color: #780000;
-    color: #fdf0d5;
-    border-radius: 50%;;
-    text-decoration: none;
-    display: flex;
-    opacity: 0;
-    pointer-events: none;
-    justify-content: center;
-    align-items: center;
-    box-shadow: 0px 0px 10px #fdf0d5;
-    transition: all .4s;
+  position: fixed;
+  height: 45px;
+  width: 45px;
+  bottom: 16px;
+  right: 30px;
+  font-size: 26px;
+  background-color: #780000;
+  color: #fdf0d5;
+  border-radius: 50%;
+  text-decoration: none;
+  display: flex;
+  opacity: 0;
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 0px 10px #fdf0d5;
+  transition: all 0.4s;
 }
 
 .back-to-top.active {
-    bottom: 30px;
-    opacity: 1;
-    pointer-events: auto;
+  bottom: 30px;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .back-to-top:focus {
-    outline:none;
+  outline: none;
 }
 
 .back-to-top:hover {
-    background-color: #fdf0d5;
-    color: #780000;
-    box-shadow: 0px 0px 10px #780000;
-    font-size: 28px;
+  background-color: #fdf0d5;
+  color: #780000;
+  box-shadow: 0px 0px 10px #780000;
+  font-size: 28px;
 }
 
 /* Top section */
 .footer-top {
   display: grid;
-  justify-content:center ;
+  justify-content: center;
   grid-template-columns: 28% 10% 13% 30%;
   gap: 40px;
   margin-bottom: 100px;
@@ -289,7 +287,7 @@ nav .fa {
   font-size: 18px;
   color: #fff8e7;
   margin-bottom: 10px;
-  font-family: 'Georgia', serif;
+  font-family: "Georgia", serif;
 }
 
 .subscription-box form {
@@ -303,7 +301,7 @@ nav .fa {
   border-radius: 15px;
   margin-bottom: 10px;
 }
-  
+
 .subscription-box button {
   background: #ffcc66;
   color: #7a0000;
@@ -320,7 +318,7 @@ nav .fa {
 .subscription-box button:hover {
   background: #e6b85c;
 }
-button:active{
+button:active {
   scale: 0.95;
 }
 /* Bottom bar */
@@ -355,7 +353,6 @@ button:active{
     width: 100%;
   }
 }
-
 
 .submit {
   width: 80%;


### PR DESCRIPTION
Contributor Info
Your Name:
nikkkhil2935

Related Issue
Fixes: #305

Description
This pull request resolves the duplicate underline issue in the main navigation bar. The redundant text-decoration: underline; property was removed from the :hover state of navigation links in the following CSS files:

style.css

about.css

masthead.css

submission.css

issue.css

faq.css

This change ensures that only the intended animated underline effect created by the ::after pseudo-element is displayed, providing a cleaner and more consistent user interface across all pages.

Screenshots / Video (Before & After)
Before:
The navigation bar items incorrectly displayed two underlines on hover, as seen in the provided screenshots.

After:
The navigation bar now correctly shows only a single, animated underline on hover, providing a clean and consistent look across all pages.
<img width="540" height="63" alt="navbar" src="https://github.com/user-attachments/assets/50e2443a-9477-4a84-b84a-2d34f86df673" />



