### PR TITLE
Fix/navbar double underline

### DIFF
--- a/about.css
+++ b/about.css
@@ -100,8 +100,7 @@ font-size: 20px
     display: block;
 }
 .nav-links ul li a:hover {
-    text-decoration: underline;
-    transition: 0.3s ease;
+    text-decoration: none; /* REMOVE underline */
 }
 
 .nav-links ul li::after {

--- a/faq.css
+++ b/faq.css
@@ -101,22 +101,25 @@ nav{
   padding: 12px 16px;
   display: block;
 }
-.nav-links ul li::after {
-  content: "";
-  width: 0%;
-  height: 2px;
-  background: #fdf0d5;
-  display: block;
-  margin: auto;
-  transition: 0.5s;
-}
+
 .nav-links ul li a:hover {
-  text-decoration: underline;
-  transition: 0.3s ease;
+    text-decoration: none; /* REMOVE underline */
 }
+
+.nav-links ul li::after {
+    content: '';
+    width: 0%;
+    height: 2px;
+    background: #fdf0d5;
+    display: block;
+    margin: auto;
+    transition: 0.5s;
+}
+
 .nav-links ul li:hover::after {
-  width: 100%;
+    width: 100%;
 }
+
 
 nav .fa {
   display: none;

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
             <li><a href="index.html">HOME</a></li>
             <li><a href="about.html">ABOUT</a></li>
             <li><a href="submission.html">SUBMIT</a></li>
+            
             <li><a href="issue.html">ISSUE</a></li>
             <li><a href="masthead.html">MASTHEAD</a></li>
             <li><a href="faq.html">FAQ</a></li>

--- a/issue.css
+++ b/issue.css
@@ -109,10 +109,10 @@ font-size: 20px
     padding: 12px 16px;
     display: block;
 }
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+    text-decoration: none; /* REMOVE underline */
 }
+
 .nav-links ul li::after {
     content: '';
     width: 0%;
@@ -126,6 +126,7 @@ font-size: 20px
 .nav-links ul li:hover::after {
     width: 100%;
 }
+
 
 nav .fa {
     display: none;

--- a/masthead.css
+++ b/masthead.css
@@ -133,22 +133,25 @@ nav{
   padding: 12px 16px;
   display: block;
 }
-.nav-links ul li::after {
-  content: "";
-  width: 0%;
-  height: 2px;
-  background: #fdf0d5;
-  display: block;
-  margin: auto;
-  transition: 0.5s;
-}
+
 .nav-links ul li a:hover {
-  text-decoration: underline;
-  transition: 0.3s ease;
+    text-decoration: none; /* REMOVE underline */
 }
+
+.nav-links ul li::after {
+    content: '';
+    width: 0%;
+    height: 2px;
+    background: #fdf0d5;
+    display: block;
+    margin: auto;
+    transition: 0.5s;
+}
+
 .nav-links ul li:hover::after {
-  width: 100%;
+    width: 100%;
 }
+
 
 nav .fa {
   display: none;

--- a/style.css
+++ b/style.css
@@ -109,9 +109,8 @@ nav {
 
 }
 
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+    text-decoration: none; /* REMOVE underline */
 }
 
 .nav-links ul li::after {
@@ -127,6 +126,7 @@ nav {
 .nav-links ul li:hover::after {
     width: 100%;
 }
+
 
 nav .fa {
     display: none;

--- a/submission.css
+++ b/submission.css
@@ -108,22 +108,22 @@ nav {
   padding: 12px 16px;
   display: block;
 }
-.nav-links ul li a:hover{
-    text-decoration: underline;
-    transition: 0.3s ease;
+.nav-links ul li a:hover {
+    text-decoration: none; /* REMOVE underline */
 }
+
 .nav-links ul li::after {
-  content: "";
-  width: 0%;
-  height: 2px;
-  background: #fdf0d5;
-  display: block;
-  margin: auto;
-  transition: 0.5s;
+    content: '';
+    width: 0%;
+    height: 2px;
+    background: #fdf0d5;
+    display: block;
+    margin: auto;
+    transition: 0.5s;
 }
 
 .nav-links ul li:hover::after {
-  width: 100%;
+    width: 100%;
 }
 
 nav .fa {


### PR DESCRIPTION
## Contributor Info
**Your Name:**  
Manali lamture

---

## Related Issue
Fixes: #305

---

## Description
This PR resolves the issue where each navbar item showed two underlines:

One from text-decoration: underline on <a>
One from ::after animation
The CSS text-decoration: underline was removed from the hover state,
so only the smooth animated underline remains.

---

## Screenshots / Video (Before & After)
### Before:
<img width="464" height="61" alt="Screenshot 2025-07-31 110349" src="https://github.com/user-attachments/assets/03f4937b-1900-4394-b528-bd2b34f18141" />


### After:
<img width="363" height="51" alt="Screenshot 2025-07-31 114135" src="https://github.com/user-attachments/assets/d22fbc24-23d8-4e4e-8fda-759d791055f4" />



