### PR TITLE
Changed the footer year code to update dynamically

### DIFF
--- a/about.html
+++ b/about.html
@@ -359,7 +359,7 @@
       </div>
       <div class="footer-bottom">
         <p>Made with &#x2665; by Kritika Singh</p>
-        <p>&copy; 2024 THE CAWNPORE — ALL RIGHTS RESERVED</p>
+        <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
       </div>
     </footer>
    

--- a/faq.html
+++ b/faq.html
@@ -246,7 +246,7 @@
       </div>
       <div class="footer-bottom">
         <p>Made with &#x2665; by Kritika Singh</p>
-        <p>&copy; 2024 THE CAWNPORE — ALL RIGHTS RESERVED</p>
+        <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
       </div>
     </footer>
     <script src="index.js"></script>

--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
       </div>
       <div class="footer-bottom">
         <p>Made with &#x2665; by Kritika Singh</p>
-        <p>&copy; 2024 THE CAWNPORE — ALL RIGHTS RESERVED</p>
+        <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
       </div>
     </footer>
 

--- a/index.js
+++ b/index.js
@@ -114,3 +114,5 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 });
 
+// Update the year in the footer
+document.getElementById("year").textContent = new Date().getFullYear();

--- a/issue.html
+++ b/issue.html
@@ -358,7 +358,7 @@
     </div>
     <div class="footer-bottom">
       <p>Made with &#x2665; by Kritika Singh</p>
-      <p>&copy; 2024 THE CAWNPORE — ALL RIGHTS RESERVED</p>
+      <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
     </div>
   </footer>
   <script src="index.js"></script>

--- a/journey.html
+++ b/journey.html
@@ -367,6 +367,7 @@
     <p>This project is part of <a href="https://github.com/TheCawnporeMag/TheCawnporeMag.github.io" target="_blank">TheCawnporeMag.github.io</a> repository</p>
     <p>We invite developers, designers, and creatives to collaborate in making this space more accessible, interactive, and beautiful</p>
     <p>Licensed under MIT | Maintained with ❤️ by The Cawnpore Magazine Team</p>
+    <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
   </div>
 
   <script>
@@ -393,6 +394,8 @@
         observer.observe(item);
       });
     });
+    // Update the year in the footer
+document.getElementById("year").textContent = new Date().getFullYear();
   </script>
 </body>
 </html>

--- a/masthead.html
+++ b/masthead.html
@@ -757,7 +757,7 @@
       </div>
       <div class="footer-bottom">
         <p>Made with &#x2665; by Kritika Singh</p>
-        <p>&copy; 2024 THE CAWNPORE — ALL RIGHTS RESERVED</p>
+        <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
       </div>
     </footer>
 

--- a/open-source.html
+++ b/open-source.html
@@ -193,7 +193,7 @@
     </div>
     <div class="footer-bottom">
       <p>Made with &#x2665; by Kritika Singh</p>
-      <p>&copy; 2024 THE CAWNPORE — ALL RIGHTS RESERVED</p>
+      <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
     </div>
   </footer>
 
@@ -285,7 +285,10 @@
     function hideMenu() {
       navLinks.style.right = "-200px";
       document.body.style.overflow = "auto";
+
     }
+    // Update the year in the footer
+document.getElementById("year").textContent = new Date().getFullYear();
   </script>
 </body>
 

--- a/submission.html
+++ b/submission.html
@@ -282,7 +282,7 @@
       </div>
       <div class="footer-bottom">
         <p>Made with &#x2665; by Kritika Singh</p>
-        <p>&copy; 2024 THE CAWNPORE — ALL RIGHTS RESERVED</p>
+        <p>&copy; <span id="year"></span> THE CAWNPORE — ALL RIGHTS RESERVED</p>
       </div>
     </footer>
 


### PR DESCRIPTION
## Contributor Info
**Name:**  
Dewansh Warjurkar

---

## Related Issue
Fixes: #327 

---

Changes Made:

Replaced hardcoded year in the footer with a dynamic value using JavaScript.
Added a <span id="year"> to the HTML and populated it using new Date().getFullYear().
Before:
© 2024 THE CAWNPORE — ALL RIGHTS RESERVED
<img width="679" height="135" alt="Screenshot 2025-08-01 191519" src="https://github.com/user-attachments/assets/ddea8378-dc5c-4da6-bfa4-4d17742b7fdd" />


After:
© {currentYear} THE CAWNPORE — ALL RIGHTS RESERVED (updates automatically every year)
<img width="588" height="122" alt="Screenshot 2025-08-01 191504" src="https://github.com/user-attachments/assets/2f785743-1c24-4a00-a41e-365c4b02d0ad" />


Closes #327 

Hi @Kritika75,

I wanted to inform you that I was unable to resolve the conflicts in my previous pull request due to a clash with another PR related to the Pointer effect. Since I wasn’t familiar with resolving such conflicts at the time, I decided to create a fresh fork, re-implement the necessary changes, and open this new pull request.

Thank you for understanding!
Happy to contribute this fix as part of GSSoC '25 🚀
