### PR TITLE
fix: improved spacing between masthead heading and page content

### DIFF
--- a/masthead.css
+++ b/masthead.css
@@ -80,7 +80,7 @@ nav {
   background-position: center;
   background-size: cover;
   position: relative;
-  padding: 20px 0;
+  padding: 20px 20px;
 }
 
 .text-box1 {
@@ -88,6 +88,7 @@ nav {
   font-family: "Crimson Text", serif;
   width: 90%;
   position: absolute;
+  margin-top: 45px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
## Contributor Info
**Your Name:**  
Ankita Gupta

---

## Related Issue
Fixes: #408 

---

## Description
Improved the vertical spacing between the main heading and the page content on the Masthead page.
This enhancement ensures better visual separation and layout consistency, especially on different screen sizes.

---

## Screenshots / Video (Before & After)
### Before:
<img width="1876" height="849" alt="image" src="https://github.com/user-attachments/assets/7573c556-1d7c-4334-997b-f089b0f740e3" />

### After:
<img width="1877" height="799" alt="image" src="https://github.com/user-attachments/assets/05050ee1-27ad-469d-bcb3-18626dc510e5" />

---

## Checklist
- [x] Mentioned the issue number in this PR.
- [x] Created a separate branch (not `main`) before committing.
- [x] Changes tested and verified.
- [x] Attached necessary screenshots/videos for clarity.
- [x] Code is clean, readable, and commented where necessary.
- [x] No merge conflicts.
- [x] Follows the design/style guide of the project.
- [x] Added contributor name above.
- [x] Confirmed that the feature fits well with the latest updated version of the website.
- [x] Ensured images and layout are responsive (look good on both desktop and small screens like phones).

---

## Extra Notes (Optional)
Let me know if any refinements are needed — happy to make adjustments based on feedback!

---
