### PR TITLE
Added Thoughtline Loader: Taglines That Speak Before the Page Does

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,6 @@
       <div class="circle"></div>
       <div class="circle"></div>
       <div class="circle"></div>
-      <div class="circle"></div>
               <script>
 
   // Coordinates for the cursor
@@ -129,7 +128,7 @@
      <div id="loading-screen"> 
          <div class="loader">
             <i class="fa-solid fa-spinner"></i>
-            <h2>Loading<span class="dots"></span></h2>
+            <span class="loader-tagline">Kanpur-born, read everywhere</span>
         </div>
     </div>
     <div class="progress-container">

--- a/index.js
+++ b/index.js
@@ -69,6 +69,17 @@ document.getElementById('searchBtn').addEventListener('click', function() {
                 emailInput.value = "";
             });
         }
+
+    // Loader logic
+    var loaderScreen = document.getElementById('loading-screen');
+    if (loaderScreen) {
+        setTimeout(function() {
+            loaderScreen.classList.add('fading');
+        }, 1700); // Start fade/scale at 1.7s
+        setTimeout(function() {
+            loaderScreen.classList.add('hidden');
+        }, 2000); // Hide after 2s
+    }
 });
 
 const container = document.getElementById('container');

--- a/style.css
+++ b/style.css
@@ -710,17 +710,72 @@ button:active{
 }
 
 .loader {
-    text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-direction: row;
+  transition: opacity 0.4s, transform 0.4s;
 }
-
+#loading-screen.fading .loader {
+  opacity: 0;
+  transform: scale(1.15);
+}
 .loader i {
-    font-size: 4.5rem;
-    animation: spin 2s linear infinite;
+  font-size: 4.5rem;
+  animation: spin 2s linear infinite;
+  transition: opacity 0.4s, transform 0.4s;
 }
-
-.loader h2 {
-    margin-top: 1.5rem;
-    font-size: 2.1rem;
+.loader-tagline {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #780000;
+  opacity: 0;
+  transform: translateX(60px);
+  animation: tagline-slide-in 0.5s cubic-bezier(0.77,0,0.175,1) 0.1s forwards, tagline-stay 1.1s linear 0.6s forwards, tagline-ready-fade 0.001s linear 1.7s forwards;
+  white-space: nowrap;
+  transition: opacity 0.4s, transform 0.4s, font-size 0.4s;
+}
+@keyframes tagline-slide-in {
+  0% {
+    opacity: 0;
+    transform: translateX(60px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+@keyframes tagline-stay {
+  0% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+@keyframes tagline-ready-fade {
+  0% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+@media (max-width: 600px) {
+  .loader {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .loader-tagline {
+    font-size: 1.25rem;
+    text-align: center;
+    margin-top: 0.5rem;
+  }
 }
 
 .dots::after {


### PR DESCRIPTION
## Contributor Info
**AditthyaSS:**  
<!-- Add your full name or preferred display name -->

---

## Related Issue
Fixes: #Issue Number
Thoughtline Loader: Taglines That Speak Before the Page Does.
Issue No https://github.com/Kritika75/TheCawnporeMag.github.io/issues/438
---

## Description
<!-- Briefly describe what you've done in this PR -->
Removed the default Loading Text and added a new text-based loading screen.
Introduced the tagline "Kanpur-born, read everywhere" with slide-in animation to enhance user engagement and strengthen branding during page load.
Structured with clean HTML containers (branded-loader and tagline-container) for easy CSS styling and animation.
---

## Screenshots / Video (Before & After)
### Before:
<!-- Add screenshots or a screen recording if applicable -->
<img width="1672" height="966" alt="image" src="https://github.com/user-attachments/assets/0303c248-7979-4157-a150-18e22873561a" />

### After:
<!-- Add screenshots or a screen recording if applicable -->
<img width="1892" height="837" alt="image" src="https://github.com/user-attachments/assets/4f1a1918-2c47-457a-a57b-9ee24c5a1576" />

---

## Checklist
- [✅] Mentioned the issue number in this PR.
- [✅] Created a separate branch (not `main`) before committing.
- [✅] Changes tested and verified.
- [✅] Attached necessary screenshots/videos for clarity.
- [✅] Code is clean, readable, and commented where necessary.
- [✅] No merge conflicts.
- [✅] Follows the design/style guide of the project.
- [✅] Added contributor name above.
- [✅] Confirmed that the feature fits well with the latest updated version of the website.
- [✅] Ensured images and layout are responsive (look good on both desktop and small screens like phones).

---

## Extra Notes (Optional)
<!-- Add anything else you'd like reviewers to know -->

---
