### PR TITLE
[UI] Fix overlapping buttons on home page (music & scroll-to-top)

### DIFF
--- a/style.css
+++ b/style.css
@@ -892,7 +892,7 @@ button:active{
 #music-toggle {
   position: fixed;
   bottom: 20px;
-  right: 20px;
+  left: 20px;
   background-color: #ffffffc0;
   border: 1px solid #ccc;
   border-radius: 50%;
@@ -1092,4 +1092,5 @@ button:active{
     nav {
         padding: 0.75rem 2%; /* Reduce overall nav padding */
     }
+
 }


### PR DESCRIPTION
### Description
Fixed the overlapping issue between the music control button and the scroll-to-top button on the home page.

This improves the UI by ensuring both buttons are:

- Fully visible
- Easily clickable
- Clearly separated for a better user experience

### Related Issues
Closes #459

### Type of Change
- [x] UI/UX Fix

### Checklist
- [x] My code follows the project’s coding style.
- [x] I have performed a self-review of my changes
- [x] UI elements are now accessible and not overlapping
- [x] My changes generate no new warnings

### Additional Context
Part of **GSSoC 2025**, Level 1.

Looking forward to your feedback! Please let me know if any changes are needed. 😊