### PR TITLE
BugFix: Adding favicon to gallery page

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -6,6 +6,7 @@
     <title>Cawnpore Gallery</title>
     <link rel="stylesheet" href="gallery.css" />
     <link rel="stylesheet" href="style.css" />
+    <link rel="icon" href="assets/favicon.ico" type="image/x-icon" />
   </head>
   <body>
     <nav role="navigation" aria-label="Main Menu">


### PR DESCRIPTION
## Contributor Info
**Your Name:**  
<!-- Add your full name or preferred display name -->

Sanchya Narula

## Related Issue
Fixes: 487


## Description
Added Favicon to Gallery page

---

## Screenshots / Video (Before & After)
### Before:
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/990a6bb9-4053-45c5-a3bb-3ed1ab2baa9b" />

### After:
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/764460ed-c69f-4cb4-a582-1ad3719baf96" />
---

## Checklist
- [x] Mentioned the issue number in this PR.
- [x] Created a separate branch (not `main`) before committing.
- [x] Changes tested and verified.
- [x] Attached necessary screenshots/videos for clarity.
- [x] Code is clean, readable, and commented where necessary.
- [x] No merge conflicts.
- [x] Follows the design/style guide of the project.
- [x] Added contributor name above.
- [x] Confirmed that the feature fits well with the latest updated version of the website.
- [x] Ensured images and layout are responsive (look good on both desktop and small screens like phones).

---

## Extra Notes (Optional)
<!-- Add anything else you'd like reviewers to know -->

---
