### PR TITLE
Link Navigation and Footer Logos to Homepage

### DIFF
--- a/about.html
+++ b/about.html
@@ -405,10 +405,14 @@
           <i class="fa-solid fa-chevron-up"></i>
       </a>
       <div class="footer-top" >
-        <div class="footer-about">
+      <div class="footer-about">
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
           <h3>The Cawnpore</h3>
-          <p>An independent magazine celebrating literary voices and untold stories.</p>
-        </div>
+        </a>
+        
+        <p>An independent magazine celebrating literary voices and untold stories.</p>
+      </div>
         <div class="footer-links"   id="footerLinks">
           <h3>Quick Links</h3>
           <ul>

--- a/about.html
+++ b/about.html
@@ -154,7 +154,9 @@
     <section class="header">
         <nav role="navigation" aria-label="Main Menu">
           <!-- Logo on the left -->
-        <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+        </a>
         
           <div class = "nav-links" id="navLinks">
             <i class="fa fa-times" onclick="hideMenu()"></i>

--- a/faq.html
+++ b/faq.html
@@ -156,7 +156,9 @@
   </div>
     <section class="header">
     <nav role="navigation" aria-label="Main Menu">
-      <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+      <a href="index.html">
+        <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+      </a>
       <!-- Hamburger Icon -->
       <i class="fa fa-bars" onclick="showMenu()"></i>
 

--- a/faq.html
+++ b/faq.html
@@ -242,7 +242,11 @@
       </a>
       <div class="footer-top">
         <div class="footer-about">
-          <h3>The Cawnpore</h3>
+          <a href="index.html">
+            <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
+            <h3>The Cawnpore</h3>
+          </a>
+        
           <p>An independent magazine celebrating literary voices and untold stories.</p>
         </div>
         <div class="footer-links">

--- a/gallery.html
+++ b/gallery.html
@@ -143,10 +143,14 @@
           <i class="fa-solid fa-chevron-up"></i>
       </a>
       <div class="footer-top">
-        <div class="footer-about">
+      <div class="footer-about">
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
           <h3>The Cawnpore</h3>
-          <p>An independent magazine celebrating literary voices and untold stories.</p>
-        </div>
+        </a>
+        
+        <p>An independent magazine celebrating literary voices and untold stories.</p>
+      </div>
         <div class="footer-links" id="footerLinks">
           <h3>Quick Links</h3>
           <ul>

--- a/gallery.html
+++ b/gallery.html
@@ -27,7 +27,9 @@
   <body>
     <nav role="navigation" aria-label="Main Menu">
       <!-- Logo on the left -->
-      <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+      <a href="index.html">
+        <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+      </a>
 
       <div class="nav-links" id="navLinks">
         <i class="fa fa-times" onclick="hideMenu()"></i>

--- a/index.html
+++ b/index.html
@@ -309,10 +309,14 @@
           <i class="fa-solid fa-chevron-up"></i>
       </a>
       <div class="footer-top" >
-        <div class="footer-about">
+      <div class="footer-about">
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
           <h3>The Cawnpore</h3>
-          <p>An independent magazine celebrating literary voices and untold stories.</p>
-        </div>
+        </a>
+        
+        <p>An independent magazine celebrating literary voices and untold stories.</p>
+      </div>
         <div class="footer-links"   id="footerLinks">
           <h3>Quick Links</h3>
           <ul>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,9 @@
     <section class="header">
       <nav role="navigation" aria-label="Main Menu">
         <!-- Logo on the left -->
-        <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+        </a>
         
         <div class="nav-links" id="navLinks">
           <i class="fa fa-times" onclick="hideMenu()"></i>

--- a/issue.html
+++ b/issue.html
@@ -243,13 +243,14 @@
         <i class="fa-solid fa-chevron-up"></i>
       </a>
       <div class="footer-top">
-        <div class="footer-about">
+      <div class="footer-about">
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
           <h3>The Cawnpore</h3>
-          <p>
-            An independent magazine celebrating literary voices and untold
-            stories.
-          </p>
-        </div>
+        </a>
+        
+        <p>An independent magazine celebrating literary voices and untold stories.</p>
+      </div>
         <div class="footer-links">
           <h3>Quick Links</h3>
           <ul>

--- a/issue.html
+++ b/issue.html
@@ -149,7 +149,9 @@
     </div>
     <section class="header">
       <nav role="navigation" aria-label="Main Menu">
-        <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+        </a>
 
         <div class="nav-links" id="navLinks">
           <i class="fa fa-times" onclick="hideMenu()"></i>

--- a/journey.html
+++ b/journey.html
@@ -508,7 +508,9 @@
   <!-- Navbar -->
   <nav role="navigation" aria-label="Main Menu">
     <!-- Logo on the left -->
-    <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+    <a href="index.html">
+      <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+    </a>
     
     <div class="nav-links" id="navLinks">
       <i class="fa fa-times" onclick="hideMenu()"></i>

--- a/masthead.html
+++ b/masthead.html
@@ -153,7 +153,9 @@
     <section class="header">
         <nav role="navigation" aria-label="Main Menu">
           <!-- Logo on the left -->
-          <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+            <a href="index.html">
+                <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+            </a>
         
           <div class = "nav-links" id="navLinks">
             <i class="fa fa-times" onclick="hideMenu()"></i>

--- a/masthead.html
+++ b/masthead.html
@@ -740,10 +740,14 @@ When she’s not lost in a new novel or jotting down story ideas in her journal,
           <i class="fa-solid fa-chevron-up"></i>
       </a>
       <div class="footer-top">
-        <div class="footer-about">
+      <div class="footer-about">
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
           <h3>The Cawnpore</h3>
-          <p>An independent magazine celebrating literary voices and untold stories.</p>
-        </div>
+        </a>
+        
+        <p>An independent magazine celebrating literary voices and untold stories.</p>
+      </div>
         <div class="footer-links">
           <h3>Quick Links</h3>
           <ul>

--- a/open-source.html
+++ b/open-source.html
@@ -229,7 +229,11 @@
     </a>
     <div class="footer-top">
       <div class="footer-about">
-        <h3>The Cawnpore</h3>
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
+          <h3>The Cawnpore</h3>
+        </a>
+        
         <p>An independent magazine celebrating literary voices and untold stories.</p>
       </div>
       <div class="footer-links">

--- a/open-source.html
+++ b/open-source.html
@@ -107,7 +107,9 @@
   <!-- Navbar -->
   <section class="header">
     <nav role="navigation" aria-label="Main Menu">
-      <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+      <a href="index.html">
+        <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+      </a>
       <div class="nav-links" id="navLinks">
         <i class="fa fa-times" onclick="hideMenu()"></i>
         <ul>

--- a/submission.html
+++ b/submission.html
@@ -161,7 +161,9 @@
 
         <nav role="navigation" aria-label="Main Menu">
           <!-- Logo on the left -->
-            <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+            <a href="index.html">
+              <img src="assets/favicon.ico" alt="Logo" class="navbar-logo" />
+            </a>
         
           <div class = "nav-links" id="navLinks">
             <i class="fa fa-times" onclick="hideMenu()"></i>

--- a/submission.html
+++ b/submission.html
@@ -277,13 +277,14 @@
         <i class="fa-solid fa-chevron-up"></i>
       </a>
       <div class="footer-top">
-        <div class="footer-about">
+      <div class="footer-about">
+        <a href="index.html">
+          <img src="assets/favicon.ico" alt="The Cawnpore Logo" style="height: 50px; margin-bottom: 10px;">
           <h3>The Cawnpore</h3>
-          <p>
-            An independent magazine celebrating literary voices and untold
-            stories.
-          </p>
-        </div>
+        </a>
+        
+        <p>An independent magazine celebrating literary voices and untold stories.</p>
+      </div>
         <div class="footer-links">
           <h3>Quick Links</h3>
           <ul>


### PR DESCRIPTION
**Related Issue**
Fixes: #545 

---
**Description**
This pull request resolves issue #545  by implementing a standard and essential navigation feature: making the main website logos in the header and footer clickable links to the homepage.

The following changes were made:
* The primary logo in the top navigation bar has been wrapped in an anchor tag (`<a>`) linking to `index.html`.
* The "THE CAWNPORE" text logo in the site footer has also been wrapped in an anchor tag (`<a>`) linking to `index.html`.
* These changes have been applied consistently across all pages to ensure uniform navigation throughout the website.

This aligns the site with standard user experience (UX) conventions, providing users with an intuitive and reliable way to return to the main page from anywhere.

---
**Screenshots / Video (Before & After)**

**Before:**
The logos in the header and footer were static elements. Clicking them had no effect.

https://github.com/user-attachments/assets/69b0b7e2-f829-426e-a7a2-1b798aacfac2




**After:**
The logos are now active links. Hovering over them shows a pointer cursor, and clicking them successfully navigates the user to the homepage.


https://github.com/user-attachments/assets/bb4361fe-50a0-4dff-be83-672695abf84e



---
**Checklist**
- [x] Mentioned the issue number in this PR.
- [x] Created a separate branch (not `main`) before committing.
- [x] Changes tested and verified across multiple pages.
- [x] Attached necessary screenshots/videos for clarity.
- [x] Code is clean, readable, and commented where necessary.
- [x] No merge conflicts.
- [x] Follows the design/style guide of the project.
- [x] Added contributor name above.
- [x] Confirmed that the feature fits well with the latest updated version of the website.
- [x] Ensured images and layout are responsive.

---