### PR TITLE
Fix: Prevent Text Breaking and Overflow in Welcome Section Cards on Small Screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -422,6 +422,12 @@ nav .fa {
     text-shadow: 0 0 5px #cea8bc, 0 0 10px #ffa7f2;
 }
 
+@media (max-width: 425px) {
+  .card {
+    height: 480px;
+  }
+}
+
 #intro {
     font-size: 19px;
     font-weight: 300;


### PR DESCRIPTION
## Contributor Info
**Your Name:**  
Ankit Matth

---

## Related Issue
Fixes: #574 

---

## Description
On smaller screens, the paragraph text in the Welcome section cards breaks awkwardly and sometimes overflows, affecting readability. This PR fixes the broken text issue on small screens by improving word wrapping and adjusting responsive styles.

---

## Screenshots / Video (Before & After)
### Before:
<img width="423" height="482" alt="478339250-499f086b-3860-45c3-bc26-6bd7ed718760" src="https://github.com/user-attachments/assets/f81970e8-3604-4a1f-a937-b7d5220a8e71" />

### After:
<img width="403" height="517" alt="Screenshot 2025-08-15 204020" src="https://github.com/user-attachments/assets/7d8fb065-7be9-4974-9136-407ab3ab3b5f" />

---

## Checklist
- [x] Mentioned the issue number in this PR.
- [x] Created a separate branch (not `main`) before committing.
- [x] Changes tested and verified.
- [x] Attached necessary screenshots/videos for clarity.
- [x] Code is clean, readable, and commented where necessary.
- [x] No merge conflicts.
- [x] Follows the design/style guide of the project.
- [x] Added contributor name above.
- [x] Confirmed that the feature fits well with the latest updated version of the website.
- [x] Ensured images and layout are responsive (look good on both desktop and small screens like phones).

---
