### PR TITLE
fixed the spacing between login and register button

### DIFF
--- a/style.css
+++ b/style.css
@@ -223,6 +223,10 @@ nav {
 
 }
 
+.nav-links ul li .btn{
+  margin: 3px;
+}
+
 .nav-links ul li a:hover {
     text-decoration: none; /* REMOVE underline */
 }


### PR DESCRIPTION
## Contributor Info
**Your Name:**  
Nilam Kumari Mahato

---

## Related Issue
Fixes: #618 

---

## Description
This PR fixes the UI issue where the Login and Register buttons in the navbar were too close to each other. On hover, they expanded and touched, making the design look congested.
---

## Screenshots / Video (Before & After)
### Before:

https://github.com/user-attachments/assets/bc80996b-55eb-4134-b667-a05dd564a54a


### After:

https://github.com/user-attachments/assets/d3a31188-9ddc-4696-8101-e7d6ea5b7c1b


---

## Checklist
- [x] Mentioned the issue number in this PR.
- [x] Created a separate branch (not `main`) before committing.
- [x] Changes tested and verified.
- [x] Attached necessary screenshots/videos for clarity.
- [x] Code is clean, readable, and commented where necessary.
- [x] No merge conflicts.
- [x] Follows the design/style guide of the project.
- [x] Added contributor name above.
- [x] Confirmed that the feature fits well with the latest updated version of the website.
- [x] Ensured images and layout are responsive (look good on both desktop and small screens like phones).

---

## Extra Notes (Optional)
Please checkout the added screen recordings.
---
