### PR TITLE
fixed 2 contact form

### DIFF
--- a/open-source.html
+++ b/open-source.html
@@ -210,55 +210,6 @@
   </div>
 
 
-  <div class="container">
-    <div class="form">
-      <div class="contact-info">
-        <h3 class="title">Let's get in touch</h3>
-        <p class="text">Connet with us in our wonderful journey. Feel free to share you thoughts , we will appreciate it &#127882; </p>
-        <div class="info">
-          <div class="information">
-            <p><i class="fa-solid fa-location-dot"></i><br>Kanpur </p>
-            <p><i class="fa-solid fa-envelope"></i><br>thecawnporemagofficial@gmail.com</p>
-          </div>
-
-          <div class="social-media">
-            <p>Connect with us</p>
-            <div class="social-icon">
-              <a href="https://www.instagram.com/thecawnporemagazine/?igsh=MWQzcXkxeGNkd29oeA%3D%3D" target="_blank"><i class="fa-brands fa-instagram"></i></a>
-               <a href="https://www.linkedin.com/company/the-cawnpore-magazine/" target="_blank"><i class="fa-brands fa-linkedin"></i></a>
-              <a href="https://x.com/TheCawnporeMag?s=09" target="_blank"><i class="fa-brands fa-x-twitter"></i></a>
-            </div>
-          </div>
-
-        </div>
-      </div>
-
-      <div class="contact-form">
-        <form
-         action="https://formspree.io/f/mzzvyzzo"
-         method="POST">
-          <h3 class="title">Contact Us</h3>
-          <div class="input-container">
-            <input type="text" name="name" class="input" required/>
-            <label for="">Username</label>
-            <span>Username</span>
-          </div>
-          <div class="input-container">
-            <input type="email" name="email" class="input" required/>
-            <label for="">Email</label>
-            <span>Email</span>
-          </div>
-          <div class="input-container textarea">
-            <textarea name="message" class="input"></textarea>
-            <label for="">Message</label>
-            <span>Message</span>
-          </div>
-          <input type="submit" value="Send" class="btn"/>
-        </form>
-      </div>
-    </div>
-  </div>
-
 
   <!-- Logos -->
   <section class="listings" style="text-align: center; margin-bottom: 40px;">


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

This pull request resolves an issue where the "Open Source" page was displaying two redundant "Contact Us" sections.

The unnecessary, duplicated contact form has been removed from the page. The layout now correctly shows only one "Get in Touch" section, which declutters the UI and eliminates user confusion.

Fixes #632 

## 🛠️ Type of Change

  - [x] Bug fix 🐛
  - [x] Code refactor 🔨

## ✅ Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have linked the issue using `Fixes #issue_number`

## 📸 Screenshots (if available)

**Before:** The 'Open Source' page displayed two separate 'Contact Us' forms.
<img width="1896" height="868" alt="Screenshot 2025-08-24 122717" src="https://github.com/user-attachments/assets/e022da32-fe82-452f-9e1e-ca0bb5d0f580" />
<img width="1623" height="695" alt="Screenshot 2025-08-24 122814" src="https://github.com/user-attachments/assets/9fbda9fc-1086-4f48-be88-59ee145c01d6" />


**After:** The 'Open Source' page now correctly displays only a single 'Contact Us' form.
<img width="1910" height="872" alt="image" src="https://github.com/user-attachments/assets/7c3731d6-e77b-423e-aa12-d8567034ce87" />


## 📚 Related Issues

  * This PR is the implementation for Issue #632 .

## 🧠 Additional Context

This change simplifies the page layout and provides a clearer call to action for users wishing to get in touch.