### PR TITLE
fixed smooth scrolling in about section

### DIFF
--- a/about.css
+++ b/about.css
@@ -3,6 +3,7 @@
 margin: 0;
 padding: 0;
 box-sizing: border-box;
+scroll-behavior: smooth;
 }
 
 body{


### PR DESCRIPTION
## Contributor Info
**Your Name:**  
Nilam Kumari Mahato

---

## Related Issue
Fixes: #633 

---

## Description
This PR fixes the issue where the Back to Top button directly jumped to the top of the page instead of smoothly scrolling.

---

## Screenshots / Video (Before & After)
### Before:

https://github.com/user-attachments/assets/60a018e3-cd02-40cb-86b3-a2d7985b7ea6



### After:

https://github.com/user-attachments/assets/450b0eee-fa30-4283-aacd-5035aa7d800c


---

## Checklist
- [x] Mentioned the issue number in this PR.
- [x] Created a separate branch (not `main`) before committing.
- [x] Changes tested and verified.
- [x] Attached necessary screenshots/videos for clarity.
- [x] Code is clean, readable, and commented where necessary.
- [x] No merge conflicts.
- [x] Follows the design/style guide of the project.
- [x] Added contributor name above.
- [x] Confirmed that the feature fits well with the latest updated version of the website.
- [x] Ensured images and layout are responsive (look good on both desktop and small screens like phones).

---

## Extra Notes (Optional)
Checkout the  screen recording that has been added.

---
