### PR TITLE
Fixed :Alignment of heading under ' Cawnpore's famous food 'section

### DIFF
--- a/about.css
+++ b/about.css
@@ -971,9 +971,13 @@ button:active {
   background: #a94442;
 }
 
-/* Mobile View */
 @media screen and (max-width: 768px) {
   .food-card {
     flex: 0 0 100%; /* 1 card visible */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
   }
 }
+


### PR DESCRIPTION
## Contributor Info
## NAME : Aditi Tangri 

---
## Related Issue
Fixes: #652 

## Description
This pull request improves the alignment of the heading in the "Cawnpore's Famous Food" section, particularly for mobile view.

## Changes Made:

- Adjusted CSS under the @media screen and (max-width: 768px) query to ensure the heading and its associated content are centered and visually consistent on smaller screens.

- Used flex properties (display: flex, flex-direction: column, align-items: center, text-align: center) to better align the contents of .food-card.

- These updates enhance readability and improve the section’s overall mobile responsiveness.



## Screenshots (Before & After)
### Before:
<img width="1080" height="1131" alt="image" src="https://github.com/user-attachments/assets/281a123d-7ea2-4086-ad02-80f7fa369566" />


### After:
<img width="1745" height="723" alt="image" src="https://github.com/user-attachments/assets/7ea84823-678f-475c-851f-9375c6b2b40d" />

Please merge this pull request.
